### PR TITLE
Distroless image for velero-plugin-for-aws

### DIFF
--- a/docker.io/velero/velero-plugin-for-aws/v1.1.0/Dockerfile
+++ b/docker.io/velero/velero-plugin-for-aws/v1.1.0/Dockerfile
@@ -1,6 +1,6 @@
-FROM docker.io/velero/velero-plugin-for-aws:v1.1.0
+FROM docker.io/velero/velero-plugin-for-aws:v1.1.0 as source
 
-USER root
-RUN apt-get -y update && apt-get upgrade -y && apt full-upgrade -y\
-    && rm -rf /var/lib/apt/lists/
+FROM gcr.io/distroless/static
+COPY --from=source /plugins/velero-plugin-for-aws /plugins/velero-plugin-for-aws
 USER nobody
+CMD ["/plugins/velero-plugin-for-aws"]


### PR DESCRIPTION
Copy velero-plugin-for-aws binary from velero/velero-plugin-for-aws to distroless/static image