### PR TITLE
CASMCMS-7546: Add build for the latest gitea rootless image

### DIFF
--- a/.github/workflows/docker.io.gitea.gitea.1.15.3-rootless.yaml
+++ b/.github/workflows/docker.io.gitea.gitea.1.15.3-rootless.yaml
@@ -1,0 +1,42 @@
+name: docker.io/gitea/gitea:1.15.3-rootless
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - .github/workflows/docker.io.gitea.gitea.1.15.3-rootless.yaml
+      - docker.io/gitea/gitea/1.15.3-rootless/**
+  pull_request:
+    branches:
+      - main
+    paths:
+      - .github/workflows/docker.io.gitea.gitea.1.15.3-rootless.yaml
+      - docker.io/gitea/gitea/1.15.3-rootless/**
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: self-hosted
+    env:
+      CONTEXT_PATH: docker.io/gitea/gitea/1.15.3-rootless
+      DOCKER_REPO: artifactory.algol60.net/csm-docker/stable/docker.io/gitea/gitea
+      DOCKER_TAG: 1.15.3-rootless
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+
+      - name: build-sign-scan
+        uses: ./.github/actions/build-sign-scan
+        with:
+          # Only push on main builds
+          docker_push: ${{ github.ref == 'refs/heads/main' }}
+          context_path: ${{ env.CONTEXT_PATH }}
+          docker_repo: ${{ env.DOCKER_REPO }}
+          docker_tag: ${{ env.DOCKER_TAG }}
+          artifactory_algol60_token: ${{ secrets.ARTIFACTORY_ALGOL60_TOKEN }}
+          cosign_gcp_project_id: ${{ secrets.COSIGN_GCP_PROJECT_ID }}
+          cosign_gcp_sa_key: ${{ secrets.COSIGN_GCP_SA_KEY }}
+          cosign_key: ${{ secrets.COSIGN_KEY }}
+          snyk_token: ${{ secrets.SNYK_TOKEN }}
+          github_sha: $GITHUB_SHA

--- a/docker.io/gitea/gitea/1.15.3-rootless/Dockerfile
+++ b/docker.io/gitea/gitea/1.15.3-rootless/Dockerfile
@@ -1,0 +1,88 @@
+# Copied from https://github.com/go-gitea/gitea/blob/v1.15.3/Dockerfile.rootless
+# Modifications are marked with # MODIFIED
+
+###################################
+#Build stage
+FROM golang:1.16-alpine3.13 AS build-env
+
+ARG GOPROXY
+ENV GOPROXY ${GOPROXY:-direct}
+
+ARG GITEA_VERSION
+ARG TAGS="sqlite sqlite_unlock_notify"
+ENV TAGS "bindata timetzdata $TAGS"
+ARG CGO_EXTRA_CFLAGS
+
+#Build deps
+RUN apk --no-cache add build-base git nodejs npm
+
+#Setup repo
+# MODIFIED (add cloning of code)
+RUN git clone https://github.com/go-gitea/gitea.git ${GOPATH}/src/code.gitea.io/gitea\
+    && cd ${GOPATH}/src/code.gitea.io/gitea\
+    && git checkout v1.15.3
+# COPY /opt/gitea ${GOPATH}/src/code.gitea.io/gitea
+# END MODIFIED
+WORKDIR ${GOPATH}/src/code.gitea.io/gitea
+
+#Checkout version if set
+RUN if [ -n "${GITEA_VERSION}" ]; then git checkout "${GITEA_VERSION}"; fi \
+ && make clean-all build
+
+# Begin env-to-ini build
+RUN go build contrib/environment-to-ini/environment-to-ini.go
+
+FROM alpine:3.13
+LABEL maintainer="maintainers@gitea.io"
+
+EXPOSE 2222 3000
+
+# MODIFIED (add apk update for vulnerabilities)
+RUN apk add --upgrade apk-tools &&  \
+    apk update && apk -U upgrade && \
+    rm -rf /var/cache/apk/*
+# END MODIFIED
+
+RUN apk --no-cache add \
+    bash \
+    ca-certificates \
+    gettext \
+    git \
+    curl \
+    gnupg
+
+RUN addgroup \
+    -S -g 1000 \
+    git && \
+  adduser \
+    -S -H -D \
+    -h /var/lib/gitea/git \
+    -s /bin/bash \
+    -u 1000 \
+    -G git \
+    git
+
+RUN mkdir -p /var/lib/gitea /etc/gitea
+RUN chown git:git /var/lib/gitea /etc/gitea
+
+# MODIFIED (Copy files from cloned code in build-env)
+COPY --from=build-env /go/src/code.gitea.io/gitea/docker/rootless /
+# END MODIFIED
+COPY --from=build-env --chown=root:root /go/src/code.gitea.io/gitea/gitea /usr/local/bin/gitea
+COPY --from=build-env --chown=root:root /go/src/code.gitea.io/gitea/environment-to-ini /usr/local/bin/environment-to-ini
+
+#git:git
+USER 1000:1000
+ENV GITEA_WORK_DIR /var/lib/gitea
+ENV GITEA_CUSTOM /var/lib/gitea/custom
+ENV GITEA_TEMP /tmp/gitea
+ENV TMPDIR /tmp/gitea
+
+#TODO add to docs the ability to define the ini to load (usefull to test and revert a config)
+ENV GITEA_APP_INI /etc/gitea/app.ini
+ENV HOME "/var/lib/gitea/git"
+VOLUME ["/var/lib/gitea", "/etc/gitea"]
+WORKDIR /var/lib/gitea
+
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
+CMD []


### PR DESCRIPTION
### Summary and Scope

Adds building of a rootless gitea image for switching all containers over to a non-root user.

### Issues and Related PRs

* Partially Resolves CASMCMS-7546

### Testing

Tested on:

* locally

Tested building the image from this Dockerfile on my local machine

### Risks and Mitigations

None