### PR TITLE
Add docker registry and label to build image

### DIFF
--- a/.github/actions/build-sign-scan/action.yaml
+++ b/.github/actions/build-sign-scan/action.yaml
@@ -7,6 +7,8 @@ inputs:
     required: true
   docker_push:
     required: true
+  docker_registry:
+    default: "artifactory.algol60.net"
   context_path:
     required: true
   artifactory_algol60_token:
@@ -34,6 +36,10 @@ runs:
     - name: Checkout repo
       uses: actions/checkout@v2
 
+    - id: date
+      run: echo "::set-output name=now::$(date +'%Y-%m-%dT%H:%M:%S')"
+      shell: bash
+
     - name: Set up Docker Buildx
       id: buildx
       uses: docker/setup-buildx-action@v1
@@ -46,7 +52,7 @@ runs:
     - name: Login to algol60 Container Registry
       uses: docker/login-action@v1
       with:
-        registry: artifactory.algol60.net
+        registry: ${{ inputs.docker_registry }}
         username: github-actions-cray-hpe
         password: ${{ inputs.artifactory_algol60_token }}
 
@@ -65,6 +71,8 @@ runs:
         tags: |
           ${{ inputs.docker_repo }}:${{ inputs.docker_tag }}
           ${{ inputs.docker_additional_tags }}
+        labels: buildDate=${{ steps.date.outputs.now }}
+
     - name: Sign
       run: |
         if [[ "true" == "${{ inputs.docker_push }}" ]]; then

--- a/.github/workflows/docker.io.curlimages.curl.7.73.0.yaml
+++ b/.github/workflows/docker.io.curlimages.curl.7.73.0.yaml
@@ -20,6 +20,7 @@ jobs:
     runs-on: self-hosted
     env:
       CONTEXT_PATH: docker.io/curlimages/curl/7.73.0
+      DOCKER_REGISTRY: artifactory.algol60.net
       DOCKER_REPO: artifactory.algol60.net/csm-docker/stable/docker.io/curlimages/curl
       DOCKER_TAG: 7.73.0
     steps:
@@ -34,6 +35,7 @@ jobs:
           context_path: ${{ env.CONTEXT_PATH }}
           docker_repo: ${{ env.DOCKER_REPO }}
           docker_tag: ${{ env.DOCKER_TAG }}
+          docker_registry: ${{ env.DOCKER_REGISTRY }}
           artifactory_algol60_token: ${{ secrets.ARTIFACTORY_ALGOL60_TOKEN }}
           cosign_gcp_project_id: ${{ secrets.COSIGN_GCP_PROJECT_ID }}
           cosign_gcp_sa_key: ${{ secrets.COSIGN_GCP_SA_KEY }}


### PR DESCRIPTION
This PR intend to solve two needs

- Adds buildDate label for the next build
- Accepts DOCKER_REGISTRY var for algol60 (but keeps default "algol60 main hostname")