### PR TITLE
CASMPET-5107: replace distroless image to ubuntu20

### DIFF
--- a/docker.io/istio/kubectl/1.5.4/Dockerfile
+++ b/docker.io/istio/kubectl/1.5.4/Dockerfile
@@ -1,5 +1,9 @@
 FROM docker.io/istio/kubectl:1.5.4 as source
 
-FROM gcr.io/distroless/static
+FROM docker.io/ubuntu:20.04
 COPY --from=source /usr/bin/kubectl /usr/bin/kubectl
+RUN apt update -y && apt install sudo -y \
+    && useradd -m --uid 1337 istio-proxy \
+    && echo "istio-proxy ALL=NOPASSWD: ALL" >> /etc/sudoers
+USER istio-proxy
 CMD ["/usr/bin/kubectl"]


### PR DESCRIPTION
- Changed distroless image to ubuntu 20.04
- Installed sudo and created user istio-proxy (source image has)
- Tested commands "sudo cmd", "/bin/bash" and "kubectl"