### PR TITLE
CASMPET-5104: Build kiali* v1.28.1 images

### DIFF
--- a/.github/workflows/quay.io.kiali.kiali-operator.v1.28.1.yaml
+++ b/.github/workflows/quay.io.kiali.kiali-operator.v1.28.1.yaml
@@ -1,0 +1,42 @@
+name: quay.io/kiali/kiali-operator:v1.28.1
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - .github/workflows/quay.io.kiali.kiali-operator.v1.28.1.yaml
+      - quay.io/kiali/kiali-operator/v1.28.1/**
+  pull_request:
+    branches:
+      - main
+    paths:
+      - .github/workflows/quay.io.kiali.kiali-operator.v1.28.1.yaml
+      - quay.io/kiali/kiali-operator/v1.28.1/**
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: self-hosted
+    env:
+      CONTEXT_PATH: quay.io/kiali/kiali-operator/v1.28.1
+      DOCKER_REPO: artifactory.algol60.net/csm-docker/stable/quay.io/kiali/kiali-operator
+      DOCKER_TAG: v1.28.1
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+
+      - name: build-sign-scan
+        uses: Cray-HPE/github-actions/build-sign-scan@main
+        with:
+          # Only push on main builds
+          docker_push: ${{ github.ref == 'refs/heads/main' }}
+          context_path: ${{ env.CONTEXT_PATH }}
+          docker_repo: ${{ env.DOCKER_REPO }}
+          docker_tag: ${{ env.DOCKER_TAG }}
+          artifactory_algol60_token: ${{ secrets.ARTIFACTORY_ALGOL60_TOKEN }}
+          cosign_gcp_project_id: ${{ secrets.COSIGN_GCP_PROJECT_ID }}
+          cosign_gcp_sa_key: ${{ secrets.COSIGN_GCP_SA_KEY }}
+          cosign_key: ${{ secrets.COSIGN_KEY }}
+          snyk_token: ${{ secrets.SNYK_TOKEN }}
+          github_sha: $GITHUB_SHA

--- a/.github/workflows/quay.io.kiali.kiali.v1.28.1.yaml
+++ b/.github/workflows/quay.io.kiali.kiali.v1.28.1.yaml
@@ -1,0 +1,42 @@
+name: quay.io/kiali/kiali:v1.28.1
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - .github/workflows/quay.io.kiali.kiali.v1.28.1.yaml
+      - quay.io/kiali/kiali/v1.28.1/**
+  pull_request:
+    branches:
+      - main
+    paths:
+      - .github/workflows/quay.io.kiali.kiali.v1.28.1.yaml
+      - quay.io/kiali/kiali/v1.28.1/**
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: self-hosted
+    env:
+      CONTEXT_PATH: quay.io/kiali/kiali/v1.28.1
+      DOCKER_REPO: artifactory.algol60.net/csm-docker/stable/quay.io/kiali/kiali
+      DOCKER_TAG: v1.28.1
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+
+      - name: build-sign-scan
+        uses: Cray-HPE/github-actions/build-sign-scan@main
+        with:
+          # Only push on main builds
+          docker_push: ${{ github.ref == 'refs/heads/main' }}
+          context_path: ${{ env.CONTEXT_PATH }}
+          docker_repo: ${{ env.DOCKER_REPO }}
+          docker_tag: ${{ env.DOCKER_TAG }}
+          artifactory_algol60_token: ${{ secrets.ARTIFACTORY_ALGOL60_TOKEN }}
+          cosign_gcp_project_id: ${{ secrets.COSIGN_GCP_PROJECT_ID }}
+          cosign_gcp_sa_key: ${{ secrets.COSIGN_GCP_SA_KEY }}
+          cosign_key: ${{ secrets.COSIGN_KEY }}
+          snyk_token: ${{ secrets.SNYK_TOKEN }}
+          github_sha: $GITHUB_SHA

--- a/quay.io/kiali/kiali-operator/v1.28.1/Dockerfile
+++ b/quay.io/kiali/kiali-operator/v1.28.1/Dockerfile
@@ -1,0 +1,7 @@
+FROM quay.io/kiali/kiali-operator:v1.28.1
+
+USER 0
+
+RUN yum -y upgrade && yum clean all
+
+USER ${USER_UID}

--- a/quay.io/kiali/kiali/v1.28.1/Dockerfile
+++ b/quay.io/kiali/kiali/v1.28.1/Dockerfile
@@ -1,0 +1,6 @@
+FROM quay.io/kiali/kiali:v1.28.1
+USER root
+RUN microdnf clean all && \
+    microdnf update --nodocs && \
+    microdnf clean all
+USER kiali


### PR DESCRIPTION
With the upgrade of istio to 1.8 we need to pick up a new version
of kiali. 1.28.1 is the latest that is compatible with istio 1.8.

I just copied what's there for the existing 1.25.0 images.