### PR TITLE
Add quay.io/cephcsi/cephcsi:v3.4.0

### DIFF
--- a/.github/workflows/quay.io.cephcsi.cephcsi.v3.4.0.yaml
+++ b/.github/workflows/quay.io.cephcsi.cephcsi.v3.4.0.yaml
@@ -1,0 +1,42 @@
+name: quay.io/cephcsi/cephcsi:v3.4.0
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - .github/workflows/quay.io.cephcsi.cephcsi.v3.4.0.yaml
+      - quay.io/cephcsi/cephcsi/v3.4.0/**
+  pull_request:
+    branches:
+      - main
+    paths:
+      - .github/workflows/quay.io.cephcsi.cephcsi.v3.4.0.yaml
+      - quay.io/cephcsi/cephcsi/v3.4.0/**
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: self-hosted
+    env:
+      CONTEXT_PATH: quay.io/cephcsi/cephcsi/v3.4.0
+      DOCKER_REPO: artifactory.algol60.net/csm-docker/stable/quay.io/cephcsi/cephcsi
+      DOCKER_TAG: v3.4.0
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+
+      - name: build-sign-scan
+        uses: Cray-HPE/github-actions/build-sign-scan@main
+        with:
+          # Only push on main builds
+          docker_push: ${{ github.ref == 'refs/heads/main' }}
+          context_path: ${{ env.CONTEXT_PATH }}
+          docker_repo: ${{ env.DOCKER_REPO }}
+          docker_tag: ${{ env.DOCKER_TAG }}
+          artifactory_algol60_token: ${{ secrets.ARTIFACTORY_ALGOL60_TOKEN }}
+          cosign_gcp_project_id: ${{ secrets.COSIGN_GCP_PROJECT_ID }}
+          cosign_gcp_sa_key: ${{ secrets.COSIGN_GCP_SA_KEY }}
+          cosign_key: ${{ secrets.COSIGN_KEY }}
+          snyk_token: ${{ secrets.SNYK_TOKEN }}
+          github_sha: $GITHUB_SHA

--- a/quay.io/cephcsi/cephcsi/v3.4.0/Dockerfile
+++ b/quay.io/cephcsi/cephcsi/v3.4.0/Dockerfile
@@ -1,0 +1,14 @@
+FROM quay.io/cephcsi/cephcsi:v3.4.0
+
+RUN yum install -y yum-plugin-versionlock\
+    && yum versionlock ceph*\
+    && yum versionlock python3-ceph*\
+    && yum versionlock libceph*\
+    && yum versionlock rbd*\
+    && yum versionlock python3-rbd*\
+    && yum versionlock librbd*\
+    && yum versionlock python3-rgw*\
+    && yum versionlock librgw*\
+    && yum versionlock python3-rados*\
+    && yum versionlock librados*\
+    && yum -y upgrade && yum clean all


### PR DESCRIPTION
This supports [CASMPET-5006](https://connect.us.cray.com/jira/browse/CASMPET-5006) and is required by https://github.com/Cray-HPE/cray-ceph-csi-cephfs/pull/4 in order to resolve vulnerabilities.