### PR TITLE
CASMPET-4486: Adding USER:GROUP as 65534:65534 to have container run as non-root user

### DIFF
--- a/docker.io/demisto/boto3py3/1.0.0.16140/Dockerfile
+++ b/docker.io/demisto/boto3py3/1.0.0.16140/Dockerfile
@@ -3,3 +3,5 @@ FROM docker.io/demisto/boto3py3:1.0.0.16140
 RUN apk add --upgrade apk-tools &&  \
     apk update && apk -U upgrade && \
     rm -rf /var/cache/apk/*
+
+USER 65534:65534


### PR DESCRIPTION
## Summary and Scope
Adding USER:GROUP as 65534:65534, to have container run as non-root user.

## Tested on which systems:
This changes has been tested on vshasta and mug !! 

## what kind of testing has been done:
After deploying the chart with the updated images, full CSM health check validation has been done, No discrepencies has been found related to the chart or the image under change.

## Jira ticket/id associated with this change:
The Jira ticket for the change: https://connect.us.cray.com/jira/browse/CASMPET-4486 