### PR TITLE
CASMPET-4483: Adding USER:GROUP as 65534:65534 to have container run as non-root user

### DIFF
--- a/docker.io/metallb/controller/v0.8.1/Dockerfile
+++ b/docker.io/metallb/controller/v0.8.1/Dockerfile
@@ -3,3 +3,5 @@ FROM docker.io/metallb/controller:v0.8.1
 RUN apk add --upgrade apk-tools &&  \
     apk update && apk -U upgrade && \
     rm -rf /var/cache/apk/*
+
+USER 65534:65534


### PR DESCRIPTION
### Summary and Scope

Adding USER:GROUP as 65534:65534, to have container run as non-root user.

### Issues and Related PRs

* Resolves https://connect.us.cray.com/jira/browse/CASMPET-4483

### Testing

Tested on:

* Virtual Shasta
* mug

Were the install/upgrade based validation checks/tests run?(goss tests/install-validation doc) Yes
Was a fresh Install tested? Y/N   If not, Why? - Chart was removed and re-deployed with the fresh images reference

### Risks and Mitigations

NA