### PR TITLE
CASMPET-5176: Adding USER:GROUP as 65534:65534 to have container run as non-root user

### DIFF
--- a/docker.io/openpolicyagent/opa/0.24.0-envoy-1/Dockerfile
+++ b/docker.io/openpolicyagent/opa/0.24.0-envoy-1/Dockerfile
@@ -7,5 +7,7 @@ RUN git clone https://github.com/open-policy-agent/opa-envoy-plugin /opt/opa-env
 FROM gcr.io/distroless/static
 COPY --from=builder /opt/opa-envoy-plugin/opa_envoy_linux_amd64 /app/opa_envoy_linux_amd64
 WORKDIR /app
+
+USER 65534:65534
 ENTRYPOINT ["./opa_envoy_linux_amd64"]
 CMD ["run"]


### PR DESCRIPTION
### Summary and Scope

Adding USER:GROUP as 65534:65534, to have container run as non-root user.

### Issues and Related PRs

* Resolves https://connect.us.cray.com/jira/browse/CASMPET-5176

### Testing

Tested on:

* Virtual Shasta
* mug

Were the install/upgrade based validation checks/tests run?(goss tests/install-validation doc) Yes
Was a fresh Install tested? Y/N   If not, Why? - Chart was removed and re-deployed with the fresh images reference

### Risks and Mitigations

NA