### PR TITLE
CASMPET-4512 : Adding USER:GROUP as 65534:65534 to have container run as non-root user

### DIFF
--- a/quay.io/k8scsi/csi-attacher/v2.1.1/Dockerfile
+++ b/quay.io/k8scsi/csi-attacher/v2.1.1/Dockerfile
@@ -2,4 +2,7 @@ FROM quay.io/k8scsi/csi-attacher:v2.1.1 as upstream
 
 FROM gcr.io/distroless/static:latest
 COPY --from=upstream ./csi-attacher* .
+
+USER 65534:65534
+
 ENTRYPOINT ["/csi-attacher"]


### PR DESCRIPTION
### Summary and Scope

Adding USER:GROUP as 65534:65534, to have container run as non-root user.

### Issues and Related PRs

* Resolves https://connect.us.cray.com/jira/browse/CASMPET-4512

### Testing

Tested on:

* Virtual Shasta
* mug

Were the install/upgrade based validation checks/tests run?(goss tests/install-validation doc) Yes
Was a fresh Install tested? Y/N   If not, Why? - Chart was removed and re-deployed with the fresh images reference

### Risks and Mitigations

NA