### PR TITLE
CASMPET-4516 : Adding USER:GROUP as 65534:65534 to have container run as non-root user

### DIFF
--- a/quay.io/k8scsi/csi-snapshotter/v2.1.0/Dockerfile
+++ b/quay.io/k8scsi/csi-snapshotter/v2.1.0/Dockerfile
@@ -1,1 +1,3 @@
 FROM quay.io/k8scsi/csi-snapshotter:v2.1.0
+
+USER 65534:65534


### PR DESCRIPTION
### Summary and Scope

Adding USER:GROUP as 65534:65534, to have container run as non-root user.

### Issues and Related PRs

* Resolves https://connect.us.cray.com/jira/browse/CASMPET-4516

### Testing

Tested on:

* Virtual Shasta
* mug

Were the install/upgrade based validation checks/tests run?(goss tests/install-validation doc) Yes
Was a fresh Install tested? Y/N   If not, Why? - Chart was removed and re-deployed with the fresh images reference

### Risks and Mitigations

NA