### PR TITLE
CASMPET-4471 : Adding USER:GROUP as 65534:65534 to have container run as non-root user

### DIFF
--- a/docker.io/library/postgres/13.2-alpine/Dockerfile
+++ b/docker.io/library/postgres/13.2-alpine/Dockerfile
@@ -4,3 +4,5 @@ RUN apk update && \
     apk add --upgrade apk-tools &&  \
     apk -U upgrade && \
     rm -rf /var/cache/apk/*
+
+USER 65534:65534


### PR DESCRIPTION
### Summary and Scope

Adding USER:GROUP as 65534:65534, to have container run as non-root user.

### Issues and Related PRs

* Resolves https://connect.us.cray.com/jira/browse/CASMPET-4471

### Testing

Tested on:

* Virtual Shasta
* mug

Were the install/upgrade based validation checks/tests run?(goss tests/install-validation doc) Yes
Was a fresh Install tested? Y/N   If not, Why? - Chart was removed and re-deployed with the fresh images reference

### Risks and Mitigations

NA