### PR TITLE
CASMPET-5177 : Adding USER:GROUP as 65534:65534 to have container run as non-root user

### DIFF
--- a/quay.io/coreos/etcd/v3.3.22/Dockerfile
+++ b/quay.io/coreos/etcd/v3.3.22/Dockerfile
@@ -3,3 +3,5 @@ FROM quay.io/coreos/etcd:v3.3.22
 RUN apk add --upgrade apk-tools &&  \
     apk update && apk -U upgrade && \
     rm -rf /var/cache/apk/*
+
+USER 65534:65534


### PR DESCRIPTION
### Summary and Scope

Adding USER:GROUP as 65534:65534, to have container run as non-root user.

### Issues and Related PRs

* Resolves https://connect.us.cray.com/jira/browse/CASMPET-5177

### Testing

Tested on:

* Virtual Shasta
* mug

Were the install/upgrade based validation checks/tests run?(goss tests/install-validation doc) Yes
Was a fresh Install tested? Y/N   If not, Why? - Chart was removed and re-deployed with the fresh images reference

### Risks and Mitigations

NA