### PR TITLE
CASMPET-5181 : Adding USER:GROUP as 65534:65534 to have container run as non-root user

### DIFF
--- a/docker.io/prom/node-exporter-smartmon/v0.1.0/Dockerfile
+++ b/docker.io/prom/node-exporter-smartmon/v0.1.0/Dockerfile
@@ -17,4 +17,6 @@ RUN chmod 755 /entrypoint.sh
 
 VOLUME ["/var/lib/node_exporter"]
 
+USER 65534:65534
+
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
### Summary and Scope

Adding USER:GROUP as 65534:65534, to have container run as non-root user.

### Issues and Related PRs

* Resolves https://connect.us.cray.com/jira/browse/CASMPET-5181

### Testing

Tested on:

* Virtual Shasta
* mug

Were the install/upgrade based validation checks/tests run?(goss tests/install-validation doc) **Yes**
Was a fresh Install tested? Y/N   If not, Why? - Chart was removed and re-deployed with the fresh **image** reference

### Risks and Mitigations

NA