### PR TITLE
CASMINST-3202 Rebuild internal docker images to address CVEs

### DIFF
--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -1,0 +1,75 @@
+@Library('csm-shared-library@main') __
+
+pipeline {
+    agent {
+        label "metal-gcp-builder"
+    }
+
+    options {
+        buildDiscarder(logRotator(numToKeepStr: "10"))
+        timestamps()
+    }
+
+    triggers {
+        cron '@daily'
+    }
+
+    stages {
+        stage("Rebuild Internal Images") {
+            steps {
+                script {
+                    // def externalRegistries = ["quay.io", "k8s.gcr.io", "gcr.io", "ghcr.io", "docker.io", "registry.opensource.zalan.do", "istio"]
+                    git(url: 'https://github.com/Cray-HPE/csm.git', branch: 'release/1.2')
+                    dockerIndex = readYaml(file: 'docker/index.yaml')
+                    int notUs = 0
+                    int noJob = 0
+                    int rebuilt = 0
+                    int upToDate = 0
+                    int total = 0
+                    dockerIndex.each { repo, repoDef ->
+                        repoDef.images.each { imageName, imageTags ->
+                            fullImageName = repo + "/" + imageName
+                            imageTags.each { imageTag ->
+                                def imageNameParts = fullImageName.split("/")
+                                total += 1
+                                def result = sh(returnStdout: true, script: "#!/bin/sh -e\nskopeo inspect docker://${fullImageName}:${imageTag} --retry-times 3 --format '{{ index .Labels \"org.label-schema.vcs-url\" }}|{{ .Created }}'").trim().split('\\|')
+                                def vcsUrl = result[0]
+                                def created = timeUtils.parseDateTime(result[1])
+                                def days = timeUtils.daysSince(created)
+                                if ( days <= 15 ) {
+                                    println("[INFO]: ${fullImageName}:${imageTag}: up to date, age: ${days}")
+                                    upToDate += 1
+                                } else if ( ! vcsUrl ) {
+                                    println("[WARNING]: ${fullImageName}:${imageTag}: is not up to date, age: ${days}, build source unknown")
+                                    notUs += 1
+                                } else if ( ! vcsUrl.startsWith("https://github.com/Cray-HPE/") ) {
+                                    println("[WARNING]: ${fullImageName}:${imageTag}: is not up to date, age: ${days}, not built by us: build source ${vcsUrl}")
+                                    notUs += 1
+                                } else {
+                                    println("[INFO]: ${fullImageName}:${imageTag}: not up to date, age: ${days}, will attempt to re-trigger a build")
+                                    def repoName = vcsUrl.split('/').last().replaceFirst(/\.git$/, "")
+                                    def workflowJob = jenkinsUtils.findJob("Cray-HPE", repoName, "v" + imageTag)
+                                    if (workflowJob) {
+                                        build(job: "Cray-HPE/${repoName}/v${imageTag}", wait: false, quietPeriod: (new Random()).nextInt(3600))
+                                        rebuilt += 1
+                                    } else {
+                                        println("[WARNING]: ${fullImageName}:${imageTag}: unable to retrigger, job which built this image/tag not found")
+                                        noJob += 1
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    echo """
+                        Statistics:
+                            Up to date: ${upToDate}
+                            Out of date, not built by us: ${notUs}
+                            Out of date, unclear how to rebuild: ${noJob}
+                            Rebuild attempted: ${rebuilt}
+                            Total: ${total}
+                        """
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary and Scope

Added Jenkins pipeline, which periodically pulls docker/index.yaml manifest and tries to re-trigger build jobs for images which are older then 15 days old. This has to be a Jenkins job, because images are also built with Jenkins.

## Issues and Related PRs

https://connect.us.cray.com/jira/browse/CASMINST-3202

## Testing

Statistics from initial run which triggered rebuild of ~40 internal images:
https://jenkins.algol60.net/job/Cray-HPE/job/container-images/job/feature%252Frebuild-internal-images/29/console

        17:37:04                          Statistics:
        17:37:04                              Up to date: 68
        17:37:04                              Out of date, not built by us: 67
        17:37:04                              Out of date, unclear how to rebuild: 3
        17:37:04                              Rebuild attempted: 39
        17:37:04                              Total: 177

Later runs require less rebuilds, as images became up to date:
https://jenkins.algol60.net/job/Cray-HPE/job/csm-rebuild-images/job/feature%252Finitial-commit/15/

        11:27:23                          Statistics:
        11:27:23                              Up to date: 102
        11:27:23                              Out of date, not built by us: 67
        11:27:23                              Out of date, unclear how to rebuild: 3
        11:27:23                              Rebuild attempted: 7
        11:27:23                              Total: 179

## Risks and Mitigations

We are currently only rebuilding images for release 1.2, which is in alpha state.

