### PR TITLE
CASMPET-5217 Add containers for strimzi 0.27.0

### DIFF
--- a/.github/workflows/quay.io.strimzi.kafka.0.27.0-kafka-2.8.0.yaml
+++ b/.github/workflows/quay.io.strimzi.kafka.0.27.0-kafka-2.8.0.yaml
@@ -1,0 +1,42 @@
+name: quay.io/strimzi/kafka:0.27.0-kafka-2.8.0
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - .github/workflows/quay.io.strimzi.kafka.0.27.0-kafka-2.8.0.yaml
+      - quay.io/strimzi/kafka/0.27.0-kafka-2.8.0/**
+  pull_request:
+    branches:
+      - main
+    paths:
+      - .github/workflows/quay.io.strimzi.kafka.0.27.0-kafka-2.8.0.yaml
+      - quay.io/strimzi/kafka/0.27.0-kafka-2.8.0/**
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: self-hosted
+    env:
+      CONTEXT_PATH: quay.io/strimzi/kafka/0.27.0-kafka-2.8.0
+      DOCKER_REPO: artifactory.algol60.net/csm-docker/stable/quay.io/strimzi/kafka
+      DOCKER_TAG: 0.27.0-kafka-2.8.0
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+
+      - name: build-sign-scan
+        uses: Cray-HPE/github-actions/build-sign-scan@main
+        with:
+          # Only push on main builds
+          docker_push: ${{ github.ref == 'refs/heads/main' }}
+          context_path: ${{ env.CONTEXT_PATH }}
+          docker_repo: ${{ env.DOCKER_REPO }}
+          docker_tag: ${{ env.DOCKER_TAG }}
+          artifactory_algol60_token: ${{ secrets.ARTIFACTORY_ALGOL60_TOKEN }}
+          cosign_gcp_project_id: ${{ secrets.COSIGN_GCP_PROJECT_ID }}
+          cosign_gcp_sa_key: ${{ secrets.COSIGN_GCP_SA_KEY }}
+          cosign_key: ${{ secrets.COSIGN_KEY }}
+          snyk_token: ${{ secrets.SNYK_TOKEN }}
+          github_sha: $GITHUB_SHA

--- a/.github/workflows/quay.io.strimzi.kafka.0.27.0-kafka-2.8.1.yaml
+++ b/.github/workflows/quay.io.strimzi.kafka.0.27.0-kafka-2.8.1.yaml
@@ -1,0 +1,42 @@
+name: quay.io/strimzi/kafka:0.27.0-kafka-2.8.1
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - .github/workflows/quay.io.strimzi.kafka.0.27.0-kafka-2.8.1.yaml
+      - quay.io/strimzi/kafka/0.27.0-kafka-2.8.1/**
+  pull_request:
+    branches:
+      - main
+    paths:
+      - .github/workflows/quay.io.strimzi.kafka.0.27.0-kafka-2.8.1.yaml
+      - quay.io/strimzi/kafka/0.27.0-kafka-2.8.1/**
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: self-hosted
+    env:
+      CONTEXT_PATH: quay.io/strimzi/kafka/0.27.0-kafka-2.8.1
+      DOCKER_REPO: artifactory.algol60.net/csm-docker/stable/quay.io/strimzi/kafka
+      DOCKER_TAG: 0.27.0-kafka-2.8.1
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+
+      - name: build-sign-scan
+        uses: Cray-HPE/github-actions/build-sign-scan@main
+        with:
+          # Only push on main builds
+          docker_push: ${{ github.ref == 'refs/heads/main' }}
+          context_path: ${{ env.CONTEXT_PATH }}
+          docker_repo: ${{ env.DOCKER_REPO }}
+          docker_tag: ${{ env.DOCKER_TAG }}
+          artifactory_algol60_token: ${{ secrets.ARTIFACTORY_ALGOL60_TOKEN }}
+          cosign_gcp_project_id: ${{ secrets.COSIGN_GCP_PROJECT_ID }}
+          cosign_gcp_sa_key: ${{ secrets.COSIGN_GCP_SA_KEY }}
+          cosign_key: ${{ secrets.COSIGN_KEY }}
+          snyk_token: ${{ secrets.SNYK_TOKEN }}
+          github_sha: $GITHUB_SHA

--- a/.github/workflows/quay.io.strimzi.kafka.0.27.0-kafka-3.0.0.yaml
+++ b/.github/workflows/quay.io.strimzi.kafka.0.27.0-kafka-3.0.0.yaml
@@ -1,0 +1,42 @@
+name: quay.io/strimzi/kafka:0.27.0-kafka-3.0.0
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - .github/workflows/quay.io.strimzi.kafka.0.27.0-kafka-3.0.0.yaml
+      - quay.io/strimzi/kafka/0.27.0-kafka-3.0.0/**
+  pull_request:
+    branches:
+      - main
+    paths:
+      - .github/workflows/quay.io.strimzi.kafka.0.27.0-kafka-3.0.0.yaml
+      - quay.io/strimzi/kafka/0.27.0-kafka-3.0.0/**
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: self-hosted
+    env:
+      CONTEXT_PATH: quay.io/strimzi/kafka/0.27.0-kafka-3.0.0
+      DOCKER_REPO: artifactory.algol60.net/csm-docker/stable/quay.io/strimzi/kafka
+      DOCKER_TAG: 0.27.0-kafka-3.0.0
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+
+      - name: build-sign-scan
+        uses: Cray-HPE/github-actions/build-sign-scan@main
+        with:
+          # Only push on main builds
+          docker_push: ${{ github.ref == 'refs/heads/main' }}
+          context_path: ${{ env.CONTEXT_PATH }}
+          docker_repo: ${{ env.DOCKER_REPO }}
+          docker_tag: ${{ env.DOCKER_TAG }}
+          artifactory_algol60_token: ${{ secrets.ARTIFACTORY_ALGOL60_TOKEN }}
+          cosign_gcp_project_id: ${{ secrets.COSIGN_GCP_PROJECT_ID }}
+          cosign_gcp_sa_key: ${{ secrets.COSIGN_GCP_SA_KEY }}
+          cosign_key: ${{ secrets.COSIGN_KEY }}
+          snyk_token: ${{ secrets.SNYK_TOKEN }}
+          github_sha: $GITHUB_SHA

--- a/.github/workflows/quay.io.strimzi.operator.0.27.0.yaml
+++ b/.github/workflows/quay.io.strimzi.operator.0.27.0.yaml
@@ -1,0 +1,42 @@
+name: quay.io/strimzi/operator:0.27.0
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - .github/workflows/quay.io.strimzi.operator.0.27.0.yaml
+      - quay.io/strimzi/operator/0.27.0/**
+  pull_request:
+    branches:
+      - main
+    paths:
+      - .github/workflows/quay.io.strimzi.operator.0.27.0.yaml
+      - quay.io/strimzi/operator/0.27.0/**
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: self-hosted
+    env:
+      CONTEXT_PATH: quay.io/strimzi/operator/0.27.0
+      DOCKER_REPO: artifactory.algol60.net/csm-docker/stable/quay.io/strimzi/operator
+      DOCKER_TAG: 0.27.0
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+
+      - name: build-sign-scan
+        uses: Cray-HPE/github-actions/build-sign-scan@main
+        with:
+          # Only push on main builds
+          docker_push: ${{ github.ref == 'refs/heads/main' }}
+          context_path: ${{ env.CONTEXT_PATH }}
+          docker_repo: ${{ env.DOCKER_REPO }}
+          docker_tag: ${{ env.DOCKER_TAG }}
+          artifactory_algol60_token: ${{ secrets.ARTIFACTORY_ALGOL60_TOKEN }}
+          cosign_gcp_project_id: ${{ secrets.COSIGN_GCP_PROJECT_ID }}
+          cosign_gcp_sa_key: ${{ secrets.COSIGN_GCP_SA_KEY }}
+          cosign_key: ${{ secrets.COSIGN_KEY }}
+          snyk_token: ${{ secrets.SNYK_TOKEN }}
+          github_sha: $GITHUB_SHA

--- a/quay.io/strimzi/kafka/0.27.0-kafka-2.8.0/Dockerfile
+++ b/quay.io/strimzi/kafka/0.27.0-kafka-2.8.0/Dockerfile
@@ -1,0 +1,4 @@
+FROM quay.io/strimzi/kafka:0.27.0-kafka-2.8.0
+USER root
+RUN microdnf -y update && microdnf clean all
+USER 1001

--- a/quay.io/strimzi/kafka/0.27.0-kafka-2.8.1/Dockerfile
+++ b/quay.io/strimzi/kafka/0.27.0-kafka-2.8.1/Dockerfile
@@ -1,0 +1,4 @@
+FROM quay.io/strimzi/kafka:0.27.0-kafka-2.8.1
+USER root
+RUN microdnf -y update && microdnf clean all
+USER 1001

--- a/quay.io/strimzi/kafka/0.27.0-kafka-3.0.0/Dockerfile
+++ b/quay.io/strimzi/kafka/0.27.0-kafka-3.0.0/Dockerfile
@@ -1,0 +1,4 @@
+FROM quay.io/strimzi/kafka:0.27.0-kafka-3.0.0
+USER root
+RUN microdnf -y update && microdnf clean all
+USER 1001

--- a/quay.io/strimzi/operator/0.27.0/Dockerfile
+++ b/quay.io/strimzi/operator/0.27.0/Dockerfile
@@ -1,0 +1,4 @@
+FROM quay.io/strimzi/operator:0.27.0
+USER root
+RUN microdnf -y update && microdnf clean all
+USER 1001


### PR DESCRIPTION
## Summary and Scope

This is to add the strimzi 0.27.0 containers needed in order to upgrade the strimzi operator to 0.27.0. This also upgrades kafka to a minimum of 2.8.0.

## Issues and Related PRs

* Partially Resolves [CASMPET-5217](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-5217)

## Testing

Validated containers built properly.

### Tested on:

  * Virtual Shasta

### Test description:

Validated that containers worked in vshasta with modified cray-kafka-operator and cray-shared-kafka charts.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why? N/A
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? N, don't have enough knowledge of how we use Kafka to test a downgrade.
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

SMA and any other Kafka users will need to validate that their code still works with Kafka 2.8.1. Strimzi CRD requests will also need to be modified to work with the new kafka.strimzi.io/v1beta2 schema.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [X] Target branch correct
- [ ] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

