### PR TITLE
Add the most recent external-dns image from upstream

### DIFF
--- a/.github/workflows/docker.io.bitnami.external-dns.0.debian-10.yaml
+++ b/.github/workflows/docker.io.bitnami.external-dns.0.debian-10.yaml
@@ -1,0 +1,42 @@
+name: docker.io/bitnami/external-dns:0.10.2-debian-10-r23
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - .github/workflows/docker.io.bitnami.external-dns.0.debian-10.yaml
+      - docker.io/bitnami/external-dns/0/debian-10/**
+  pull_request:
+    branches:
+      - main
+    paths:
+      - .github/workflows/docker.io.bitnami.external-dns.0.debian-10.yaml
+      - docker.io/bitnami/external-dns/0/debian-10/**
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: self-hosted
+    env:
+      CONTEXT_PATH: docker.io/bitnami/external-dns/0/debian-10
+      DOCKER_REPO: artifactory.algol60.net/csm-docker/stable/docker.io/bitnami/external-dns/0/debian-10
+      DOCKER_TAG: 0.10.2-debian-10-r23
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+
+      - name: build-sign-scan
+        uses: Cray-HPE/github-actions/build-sign-scan@main
+        with:
+          # Only push on main builds
+          docker_push: ${{ github.ref == 'refs/heads/main' }}
+          context_path: ${{ env.CONTEXT_PATH }}
+          docker_repo: ${{ env.DOCKER_REPO }}
+          docker_tag: ${{ env.DOCKER_TAG }}
+          artifactory_algol60_token: ${{ secrets.ARTIFACTORY_ALGOL60_TOKEN }}
+          cosign_gcp_project_id: ${{ secrets.COSIGN_GCP_PROJECT_ID }}
+          cosign_gcp_sa_key: ${{ secrets.COSIGN_GCP_SA_KEY }}
+          cosign_key: ${{ secrets.COSIGN_KEY }}
+          snyk_token: ${{ secrets.SNYK_TOKEN }}
+          github_sha: $GITHUB_SHA

--- a/docker.io/bitnami/external-dns/0/debian-10/Dockerfile
+++ b/docker.io/bitnami/external-dns/0/debian-10/Dockerfile
@@ -1,0 +1,6 @@
+FROM bitnami/external-dns:0.10.2-debian-10-r23
+
+USER root
+RUN apt-get update && apt-get upgrade -y && apt full-upgrade -y \
+    && rm -rf /var/lib/apt/lists/*
+USER 1001


### PR DESCRIPTION
## Summary and Scope

Add the most recent external-dns image from upstream with less critical and high CVEs.

## Issues and Related PRs

* Partially Resolves [CASMPET-5212]

## Testing

### Tested on:

  * Virtual Shasta

### Test description:

The new image will be validated once rebuilt and deployed in an updated chart.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

Low.

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

