### PR TITLE
CASMPET-5217 Add strimzi/kafka-bridge:0.21.2

### DIFF
--- a/.github/workflows/quay.io.strimzi.kafka-bridge.0.21.2.yaml
+++ b/.github/workflows/quay.io.strimzi.kafka-bridge.0.21.2.yaml
@@ -1,0 +1,42 @@
+name: quay.io/strimzi/kafka-bridge:0.21.2
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - .github/workflows/quay.io.strimzi.kafka-bridge.0.21.2.yaml
+      - quay.io/strimzi/kafka-bridge/0.21.2/**
+  pull_request:
+    branches:
+      - main
+    paths:
+      - .github/workflows/quay.io.strimzi.kafka-bridge.0.21.2.yaml
+      - quay.io/strimzi/kafka-bridge/0.21.2/**
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: self-hosted
+    env:
+      CONTEXT_PATH: quay.io/strimzi/kafka-bridge/0.21.2
+      DOCKER_REPO: artifactory.algol60.net/csm-docker/stable/quay.io/strimzi/kafka-bridge
+      DOCKER_TAG: 0.21.2
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+
+      - name: build-sign-scan
+        uses: Cray-HPE/github-actions/build-sign-scan@main
+        with:
+          # Only push on main builds
+          docker_push: ${{ github.ref == 'refs/heads/main' }}
+          context_path: ${{ env.CONTEXT_PATH }}
+          docker_repo: ${{ env.DOCKER_REPO }}
+          docker_tag: ${{ env.DOCKER_TAG }}
+          artifactory_algol60_token: ${{ secrets.ARTIFACTORY_ALGOL60_TOKEN }}
+          cosign_gcp_project_id: ${{ secrets.COSIGN_GCP_PROJECT_ID }}
+          cosign_gcp_sa_key: ${{ secrets.COSIGN_GCP_SA_KEY }}
+          cosign_key: ${{ secrets.COSIGN_KEY }}
+          snyk_token: ${{ secrets.SNYK_TOKEN }}
+          github_sha: $GITHUB_SHA

--- a/quay.io/strimzi/kafka-bridge/0.21.2/Dockerfile
+++ b/quay.io/strimzi/kafka-bridge/0.21.2/Dockerfile
@@ -1,0 +1,4 @@
+FROM quay.io/strimzi/kafka-bridge:0.21.2
+USER root
+RUN microdnf -y update && microdnf clean all
+USER 1001


### PR DESCRIPTION
## Summary and Scope

Adds strimzi/kafka-bridge:0.21.2 image for use with strimzi 0.27.0

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Partially Resolves [CASMPET-5217](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-5217

## Testing

Verified image builds. None of our services currently use the kafka bridge. However, it's needed in case it's requested via the operator.


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

