### PR TITLE
CASMINST-3742 Compile zeromq with libsodium support

### DIFF
--- a/docker.io/zeromq/zeromq/v4.0.5/Dockerfile
+++ b/docker.io/zeromq/zeromq/v4.0.5/Dockerfile
@@ -3,13 +3,13 @@ FROM ubuntu:20.04
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt -y update && apt-get install -y wget build-essential libtool autoconf automake pkg-config unzip libkrb5-dev
 
-RUN cd /tmp && wget http://download.zeromq.org/zeromq-4.0.5.tar.gz && \
-    tar xzvf zeromq-4.0.5.tar.gz && cd /tmp/zeromq-4.0.5 && ./configure -prefix=/usr && \
-    make && make install && ldconfig
-
 RUN cd /tmp && wget https://github.com/jedisct1/libsodium/archive/1.0.0.zip && unzip 1.0.0.zip && \
     cd libsodium-1.0.0 && ./autogen.sh && ./configure --prefix=/usr && \
-    make check && make install && ldconfig
+    make check && make install && ldconfig && rm -Rf 1.0.0.zip libsodium-1.0.0
+
+RUN cd /tmp && wget http://download.zeromq.org/zeromq-4.0.5.tar.gz && \
+    tar xzvf zeromq-4.0.5.tar.gz && cd /tmp/zeromq-4.0.5 && ./configure -prefix=/usr && \
+    make && make install && ldconfig && rm -Rf zeromq-4.0.5.tar.gz zeromq-4.0.5
 
 RUN apt-get -y update && apt-get upgrade -y && apt full-upgrade -y \
     && rm -rf /var/lib/apt/lists/


### PR DESCRIPTION
## Summary and Scope
Change order of installing zeromq and libsodium. Thus, by the time of zeromq compilation, libsodium is already present on image filesystem, and libzeromq gets statically compiled with libsodium (needed for CURVE security support).

Not sure how this worked before - most likely a 7 years old image from `arti.dev.cray.com/third-party-docker-stable-local/zeromq/zeromq` was used. When it was replaced with `artifactory.algol60.net/csm-docker/stable/docker.io/zeromq/zeromq`, it appeared that the latter is broken and [CASMINST-3742](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-3742) was filed.

## Issues and Related PRs

* Resolves [CASMINST-3742](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-3742)

## Testing

Tested locally.

### Tested on:

  * local

### Test description:

Before change:

    $ docker run -it --rm artifactory.algol60.net/csm-docker/stable/docker.io/zeromq/zeromq:v4.0.5 curve_keygen
    This tool generates a CurveZMQ keypair, as two printable strings you can
    use in configuration files or source code. The encoding uses Z85, which
    is a base-85 format that is described in 0MQ RFC 32, and which has an
    implementation in the z85_codec.h source used by this tool. The keypair
    always works with the secret key held by one party and the public key
    distributed (securely!) to peers wishing to connect to it.
    To use curve_keygen, please install libsodium and then rebuild libzmq.

After change:

    $ docker run -it --rm artifactory.algol60.net/csm-docker/stable/docker.io/zeromq/zeromq:v4.0.5-my curve_keygen
    This tool generates a CurveZMQ keypair, as two printable strings you can
    use in configuration files or source code. The encoding uses Z85, which
    is a base-85 format that is described in 0MQ RFC 32, and which has an
    implementation in the z85_codec.h source used by this tool. The keypair
    always works with the secret key held by one party and the public key
    distributed (securely!) to peers wishing to connect to it.
    
    == CURVE PUBLIC KEY ==
    Y+3mC/*-I(+2/4PWD50*+1&c)ty<%Xs{36!]41K<
    
    == CURVE SECRET KEY ==
    +jz>@*><JH1MTKOS::I&*cd7#IvR&#WA1$-?XWvv

Also, in build log before change:
    
    #6 10.85 checking for sodium_init in -lsodium... no
    #6 10.91 configure: WARNING: libsodium is needed for CURVE security

After change:

    #7 7.977 checking for sodium_init in -lsodium... yes

## Risks and Mitigations

Risk is minimal - this was never worked before

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

