### PR TITLE
CASMCMS-7817 - CVE vulnerabilities in dckr.io/alpine/git:v2.32.0.

### DIFF
--- a/.github/workflows/docker.io.alpine.git.2.32.0.yaml
+++ b/.github/workflows/docker.io.alpine.git.2.32.0.yaml
@@ -1,0 +1,65 @@
+#
+# MIT License
+#
+# (C) Copyright [2022] Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+name: docker.io/alpine/git:2.32.0
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - .github/workflows/docker.io.alpine.git.2.32.0.yaml
+      - docker.io/alpine/git/2.32.0/**
+  pull_request:
+    branches:
+      - main
+    paths:
+      - .github/workflows/docker.io.alpine.git.2.32.0.yaml
+      - docker.io/alpine/git/2.32.0/**
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: self-hosted
+    env:
+      CONTEXT_PATH: docker.io/alpine/git/2.32.0
+      DOCKER_REPO: artifactory.algol60.net/csm-docker/stable/docker.io/alpine/git
+      DOCKER_TAG: 2.32.0
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+
+      - name: build-sign-scan
+        uses: Cray-HPE/github-actions/build-sign-scan@main
+        with:
+          # Only push on main builds
+          docker_push: ${{ github.ref == 'refs/heads/main' }}
+          context_path: ${{ env.CONTEXT_PATH }}
+          docker_repo: ${{ env.DOCKER_REPO }}
+          docker_tag: ${{ env.DOCKER_TAG }}
+          artifactory_algol60_token: ${{ secrets.ARTIFACTORY_ALGOL60_TOKEN }}
+          cosign_gcp_project_id: ${{ secrets.COSIGN_GCP_PROJECT_ID }}
+          cosign_gcp_sa_key: ${{ secrets.COSIGN_GCP_SA_KEY }}
+          cosign_key: ${{ secrets.COSIGN_KEY }}
+          snyk_token: ${{ secrets.SNYK_TOKEN }}
+          github_sha: $GITHUB_SHA

--- a/docker.io/alpine/git/2.32.0/Dockerfile
+++ b/docker.io/alpine/git/2.32.0/Dockerfile
@@ -1,0 +1,28 @@
+#
+# MIT License
+#
+# (C) Copyright [2022] Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+FROM alpine/git:v2.32.0
+
+RUN apk add --upgrade apk-tools &&  \
+    apk update && apk -U upgrade && \
+    rm -rf /var/cache/apk/*


### PR DESCRIPTION
## Summary and Scope

There are CVE vulnerabilities in the base image that are resolved by a rebuild but it looks like the official image isn't rebuilt on a regular basis.  Moving this into here to rebuild and give us a patched version that we can use.

## Issues and Related PRs
* Resolves [CSAMCMS-7817](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-7817)

## Testing
### Tested on:
  * Local development environment

### Test description:
Built the image manually on local box and used snyk to determine that a rebuild will resolve the vulnerabilities.

## Risks and Mitigations
Low risk - just running update on the provided base image.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
