### PR TITLE
CASMINST-4082: add pgbouncer master-21 release from upstream

### DIFF
--- a/.github/workflows/registry.opensource.zalan.do.acid.pgbouncer.master-21.yaml
+++ b/.github/workflows/registry.opensource.zalan.do.acid.pgbouncer.master-21.yaml
@@ -1,0 +1,65 @@
+#
+# MIT License
+#
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+name: registry.opensource.zalan.do/acid/pgbouncer:master-21
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - .github/workflows/registry.opensource.zalan.do.acid.pgbouncer.master-21.yaml
+      - registry.opensource.zalan.do/acid/pgbouncer/master-21/**
+  pull_request:
+    branches:
+      - main
+    paths:
+      - .github/workflows/registry.opensource.zalan.do.acid.pgbouncer.master-21.yaml
+      - registry.opensource.zalan.do/acid/pgbouncer/master-21/**
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: self-hosted
+    env:
+      CONTEXT_PATH: registry.opensource.zalan.do/acid/pgbouncer/master-21
+      DOCKER_REPO: artifactory.algol60.net/csm-docker/stable/registry.opensource.zalan.do/acid/pgbouncer
+      DOCKER_TAG: master-21
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+
+      - name: build-sign-scan
+        uses: Cray-HPE/github-actions/build-sign-scan@main
+        with:
+          # Only push on main builds
+          docker_push: ${{ github.ref == 'refs/heads/main' }}
+          context_path: ${{ env.CONTEXT_PATH }}
+          docker_repo: ${{ env.DOCKER_REPO }}
+          docker_tag: ${{ env.DOCKER_TAG }}
+          artifactory_algol60_token: ${{ secrets.ARTIFACTORY_ALGOL60_TOKEN }}
+          cosign_gcp_project_id: ${{ secrets.COSIGN_GCP_PROJECT_ID }}
+          cosign_gcp_sa_key: ${{ secrets.COSIGN_GCP_SA_KEY }}
+          cosign_key: ${{ secrets.COSIGN_KEY }}
+          snyk_token: ${{ secrets.SNYK_TOKEN }}
+          github_sha: $GITHUB_SHA

--- a/registry.opensource.zalan.do/acid/pgbouncer/master-21/Dockerfile
+++ b/registry.opensource.zalan.do/acid/pgbouncer/master-21/Dockerfile
@@ -1,0 +1,32 @@
+#
+# MIT License
+#
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+FROM registry.opensource.zalan.do/acid/pgbouncer:master-21
+
+USER root
+
+RUN apk add --upgrade apk-tools &&  \
+    apk update && apk -U upgrade && \
+    rm -rf /var/cache/apk/*
+
+USER pgbouncer


### PR DESCRIPTION
## Summary and Scope

Add pgbouncer master-21 docker image from upstream. The master-19 docker image we currently use is based on alpine 3.12.8, with 0 critical and 10 high CVEs. The new master-21 docker image is based on alpine 3.12.9, with 0 critical and only 1 high CVE.

## Issues and Related PRs

* Resolves [CASMINST-4082]

## Testing

_List the environments in which these changes were tested._

### Tested on:

Will be tested with a new chart PR on a bare metal system or vshasta.

## Risks and Mitigations

Low. This is minor release update.

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

