### PR TITLE
CASMINST-4257 - create image docker.io/gitea/gitea:1.16.4-rootless.

### DIFF
--- a/.github/workflows/docker.io.gitea.gitea.1.16.4-rootless.yaml
+++ b/.github/workflows/docker.io.gitea.gitea.1.16.4-rootless.yaml
@@ -1,0 +1,68 @@
+#
+# MIT License
+#
+# (C) Copyright [2022] Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+name: docker.io/gitea/gitea:1.16.4-rootless
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - .github/workflows/docker.io.gitea.gitea.1.16.4-rootless.yaml
+      - docker.io/gitea/gitea/1.16.4-rootless/**
+  pull_request:
+    branches:
+      - main
+    paths:
+      - .github/workflows/docker.io.gitea.gitea.1.16.4-rootless.yaml
+      - docker.io/gitea/gitea/1.16.4-rootless/**
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      CONTEXT_PATH: docker.io/gitea/gitea/1.16.4-rootless
+      DOCKER_REPO: artifactory.algol60.net/csm-docker/stable/docker.io/gitea/gitea
+      DOCKER_TAG: 1.16.4-rootless
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+
+      - name: build-sign-scan
+        uses: Cray-HPE/github-actions/build-sign-scan@main
+        with:
+          # Only push on main builds
+          docker_push: ${{ github.ref == 'refs/heads/main' }}
+          context_path: ${{ env.CONTEXT_PATH }}
+          docker_repo: ${{ env.DOCKER_REPO }}
+          docker_tag: ${{ env.DOCKER_TAG }}
+          artifactory_algol60_token: ${{ secrets.ARTIFACTORY_ALGOL60_TOKEN }}
+          cosign_gcp_workload_identity_provider: ${{ secrets.COSIGN_GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          cosign_gcp_service_account: ${{ secrets.COSIGN_GCP_SERVICE_ACCOUNT }}
+          cosign_key: ${{ secrets.COSIGN_KEY }}
+          snyk_token: ${{ secrets.SNYK_TOKEN }}
+          github_sha: $GITHUB_SHA

--- a/docker.io/gitea/gitea/1.16.4-rootless/Dockerfile
+++ b/docker.io/gitea/gitea/1.16.4-rootless/Dockerfile
@@ -1,0 +1,35 @@
+#
+# MIT License
+#
+# (C) Copyright [2022] Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+FROM docker.io/gitea/gitea:1.16.4-rootless
+
+# In order to run apk, we must change to the root user
+USER root
+RUN apk add --upgrade apk-tools &&  \
+    apk update && apk -U upgrade && \
+    rm -rf /var/cache/apk/*
+
+# NOTE: USER 1000:1000 is the user specified in the Dockerfile for the
+# docker.io/gitea/gitea:1.16.4-rootless build found here:
+# https://hub.docker.com/layers/gitea/gitea/1.16.4-rootless/images/sha256-f08e7e450c02d17c08da2b5cb7b2742d520bc3bfe80749e5600b3fa3e95d15b2?context=explore
+USER 1000:1000


### PR DESCRIPTION
## Summary and Scope

The previous version of gitea docker.io/gitea/gitea:1.15.3-rootless has a CVE vulnerability in its base image.  The fix to patch the image in place was not cleared for inclusion into csm-1.2, so we had to create a new updated version with a different tag to resolve this in csm-1.2.5 and later releases.

The update gitea image now provides a rootless base image, so rather than building it ourselves like we had to do for the 1.15.3 version, we have reverted to pulling the provided image directly and just applying security patches to it.

## Issues and Related PRs
* Resolves [CASMINST-4257](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-4257)
* Change will also be needed in https://github.com/Cray-HPE/gitea to pull this image.

## Testing
### Test description:

No testing done at this stage - need to get the image  built and accessible before I can test it on a system.  

## Risks and Mitigations

Fairly low risk as this is just updating the version of the gitea base image we are using, no significant changes to the system.

## Pull Request Checklist
- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable
