### PR TITLE
CASMPET-5534: rebuild oauth2-proxy container image

### DIFF
--- a/.github/workflows/quay.io.oauth2-proxy.oauth2-proxy.v7.2.1.yaml
+++ b/.github/workflows/quay.io.oauth2-proxy.oauth2-proxy.v7.2.1.yaml
@@ -1,0 +1,70 @@
+#
+# MIT License
+#
+# (C) Copyright [2022] Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+name: quay.io/oauth2-proxy/oauth2-proxy:v7.2.1
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - .github/workflows/quay.io.oauth2-proxy.oauth2-proxy.v7.2.1.yaml
+      - quay.io/oauth2-proxy/oauth2-proxy/v7.2.1/**
+  pull_request:
+    branches:
+      - main
+    paths:
+      - .github/workflows/quay.io.oauth2-proxy.oauth2-proxy.v7.2.1.yaml
+      - quay.io/oauth2-proxy/oauth2-proxy/v7.2.1/**
+  workflow_dispatch:
+  schedule:
+    - cron: '36 11 * * *'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      CONTEXT_PATH: quay.io/oauth2-proxy/oauth2-proxy/v7.2.1
+      DOCKER_REPO: artifactory.algol60.net/csm-docker/stable/quay.io/oauth2-proxy/oauth2-proxy
+      DOCKER_TAG: v7.2.1
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+
+      - name: build-sign-scan
+        uses: Cray-HPE/github-actions/build-sign-scan@main
+        with:
+          # Only push on main builds
+          docker_push: ${{ github.ref == 'refs/heads/main' }}
+          context_path: ${{ env.CONTEXT_PATH }}
+          docker_repo: ${{ env.DOCKER_REPO }}
+          docker_tag: ${{ env.DOCKER_TAG }}
+          artifactory_algol60_token: ${{ secrets.ARTIFACTORY_ALGOL60_TOKEN }}
+          cosign_gcp_workload_identity_provider: ${{ secrets.COSIGN_GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          cosign_gcp_service_account: ${{ secrets.COSIGN_GCP_SERVICE_ACCOUNT }}
+          cosign_key: ${{ secrets.COSIGN_KEY }}
+          snyk_token: ${{ secrets.SNYK_TOKEN }}
+          github_sha: $GITHUB_SHA

--- a/docker.io/timothyb89/monasca-sidecar/1.0.0/Dockerfile
+++ b/docker.io/timothyb89/monasca-sidecar/1.0.0/Dockerfile
@@ -23,7 +23,7 @@
 #
 FROM timothyb89/monasca-sidecar:1.0.0 as upstream
 
-FROM python:3.9.9-alpine
+FROM python:3-alpine
 RUN apk add --upgrade apk-tools &&  \
     apk update && apk -U upgrade && \
     rm -rf /var/cache/apk/*

--- a/quay.io/oauth2-proxy/oauth2-proxy/v7.2.1/Dockerfile
+++ b/quay.io/oauth2-proxy/oauth2-proxy/v7.2.1/Dockerfile
@@ -1,0 +1,33 @@
+#
+# MIT License
+#
+# (C) Copyright [2022] Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+FROM quay.io/oauth2-proxy/oauth2-proxy:v7.2.1 
+
+USER root
+
+RUN apk update && \
+    apk add --upgrade apk-tools &&  \
+    apk -U upgrade && \
+    rm -rf /var/cache/apk/*
+
+USER 65532:65532


### PR DESCRIPTION
## Summary and Scope

The upstream oauth2-proxy image uses an older version of alpine image (3.15.0) with a few critical or high CVEs. By rebuilding it in our repo, we can improve the turn-around time for CVE remediation.

## Issues and Related PRs

* Resolves [CASMPET-5534]

## Testing
Will test with chart changes after image is rebuilt.

### Tested on:

  * `<development system>`
  * Local development environment
  * Virtual Shasta

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

Low.

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

