### PR TITLE
CASMMON-145: change node-exporter image base Debian package

### DIFF
--- a/quay.io/galexrt/node-exporter-smartmon/v0.1.1/Dockerfile
+++ b/quay.io/galexrt/node-exporter-smartmon/v0.1.1/Dockerfile
@@ -21,14 +21,16 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
-FROM debian:bullseye-slim
+FROM docker.io/library/alpine:3.15
 
-
-RUN apt-get -q update && \
-    apt-get install -y --no-install-recommends smartmontools nvme-cli jq moreutils git ca-certificates && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \
-    mkdir -p /scripts && \
+RUN apk add --no-cache \
+    smartmontools \
+    jq \
+    nvme-cli \
+    bash \
+    hwids-pci \ 
+    git 
+RUN mkdir -p /scripts && \
     git clone --depth 1 --branch master --single-branch \
         https://github.com/prometheus-community/node-exporter-textfile-collector-scripts.git \
         /scripts && \


### PR DESCRIPTION
## Summary and Scope

_Summarize what has changed. Explain why this PR is necessary. What is impacted? Is this a new feature, critical bug fix, etc?_

Earlier node-exporter image uses Debian package which tends to have higher CVE counts. Now changed it to more secure alpine as base OS image for node-exporter to reduce CVE counts.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves: https://jira-pro.its.hpecorp.net:8443/browse/CASMMON-145

## Testing

_List the environments in which these changes were tested._

### Tested on:

Slice and Frigg

### SLICE:

![image](https://user-images.githubusercontent.com/53111642/164627066-bac222a1-c7ae-4bcb-9566-109776e2dfa0.png)

![image](https://user-images.githubusercontent.com/53111642/164627132-4cf3c672-03ea-49d5-9f23-a5e68c9894ce.png)

![image](https://user-images.githubusercontent.com/53111642/164627211-925b1b7e-52fd-400a-b6a7-06758b8d1499.png)


### FRIGG:

![image](https://user-images.githubusercontent.com/53111642/164627268-2560af4b-e581-42b5-88a7-f511f231ce38.png)

