### PR TITLE
CASMPET-5602: relocate sealed-secrets-controller per upstream

### DIFF
--- a/.github/workflows/docker.io.bitnami.sealed-secrets-controller.v0.12.1.yaml
+++ b/.github/workflows/docker.io.bitnami.sealed-secrets-controller.v0.12.1.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright [2022] Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -21,21 +21,21 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
-name: quay.io/bitnami/sealed-secrets-controller:v0.12.1
+name: docker.io/bitnami/sealed-secrets-controller:v0.12.1
 
 on:
   push:
     branches:
       - main
     paths:
-      - .github/workflows/quay.io.bitnami.sealed-secrets-controller.v0.12.1.yaml
-      - quay.io/bitnami/sealed-secrets-controller/v0.12.1/**
+      - .github/workflows/docker.io.bitnami.sealed-secrets-controller.v0.12.1.yaml
+      - docker.io/bitnami/sealed-secrets-controller/v0.12.1/**
   pull_request:
     branches:
       - main
     paths:
-      - .github/workflows/quay.io.bitnami.sealed-secrets-controller.v0.12.1.yaml
-      - quay.io/bitnami/sealed-secrets-controller/v0.12.1/**
+      - .github/workflows/docker.io.bitnami.sealed-secrets-controller.v0.12.1.yaml
+      - docker.io/bitnami/sealed-secrets-controller/v0.12.1/**
   workflow_dispatch:
   schedule:
     - cron: '51 12 * * *'
@@ -47,8 +47,8 @@ jobs:
       contents: read
       id-token: write
     env:
-      CONTEXT_PATH: quay.io/bitnami/sealed-secrets-controller/v0.12.1
-      DOCKER_REPO: artifactory.algol60.net/csm-docker/stable/quay.io/bitnami/sealed-secrets-controller
+      CONTEXT_PATH: docker.io/bitnami/sealed-secrets-controller/v0.12.1
+      DOCKER_REPO: artifactory.algol60.net/csm-docker/stable/docker.io/bitnami/sealed-secrets-controller
       DOCKER_TAG: v0.12.1
     steps:
       - name: Checkout repo

--- a/docker.io/bitnami/sealed-secrets-controller/v0.12.1/Dockerfile
+++ b/docker.io/bitnami/sealed-secrets-controller/v0.12.1/Dockerfile
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright [2022] Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -21,4 +21,4 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
-FROM quay.io/bitnami/sealed-secrets-controller:v0.12.1
+FROM docker.io/bitnami/sealed-secrets-controller:v0.12.1


### PR DESCRIPTION
## Summary and Scope

The upstream has moved sealed-secrets-controller from quay.io to docker.io, but we are still referring to the old location. This PR relocates sealed-secrets-controller, consistent with upstream.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMPET-5602](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-5602)

## Testing

Will be tested along with an upcoming chart change.

### Tested on:

  * `<development system>`
  * Local development environment
  * Virtual Shasta

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

Low.


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

