### PR TITLE
CASMCMS-8006 - Update munge-munge image to pull updates from correct location.

### DIFF
--- a/munge-munge/1.1.3/Dockerfile
+++ b/munge-munge/1.1.3/Dockerfile
@@ -29,10 +29,10 @@ ARG SLES_MIRROR="https://${SLES_REPO_USERNAME}:${SLES_REPO_PASSWORD}@artifactory
 ARG ARCH=x86_64
 RUN \
   zypper --non-interactive rr --all && \
-  zypper --non-interactive ar ${SLES_MIRROR}/Products/SLE-Module-Basesystem/15-SP2/${ARCH}/product?auth=basic sles15sp2-Module-Basesystem-product && \
-  zypper --non-interactive ar ${SLES_MIRROR}/Updates/SLE-Module-Basesystem/15-SP2/${ARCH}/update?auth=basic sles15sp2-Module-Basesystem-update && \
-  zypper --non-interactive ar ${SLES_MIRROR}/Products/SLE-Module-HPC/15-SP2/${ARCH}/product?auth=basic sles15sp2-Module-HPC-product && \
-  zypper --non-interactive ar ${SLES_MIRROR}/Updates/SLE-Module-HPC/15-SP2/${ARCH}/update?auth=basic sles15sp2-Module-HPC-update && \
+  zypper --non-interactive ar ${SLES_MIRROR}/Products/SLE-Module-Basesystem/15-SP3/${ARCH}/product?auth=basic sles15sp3-Module-Basesystem-product && \
+  zypper --non-interactive ar ${SLES_MIRROR}/Updates/SLE-Module-Basesystem/15-SP3/${ARCH}/update?auth=basic sles15sp3-Module-Basesystem-update && \
+  zypper --non-interactive ar ${SLES_MIRROR}/Products/SLE-Module-HPC/15-SP3/${ARCH}/product?auth=basic sles15sp3-Module-HPC-product && \
+  zypper --non-interactive ar ${SLES_MIRROR}/Updates/SLE-Module-HPC/15-SP3/${ARCH}/update?auth=basic sles15sp3-Module-HPC-update && \
   zypper update -y && \
   zypper install -y munge && \
   zypper clean -a && zypper --non-interactive rr --all && rm -f /etc/zypp/repos.d/* && rm -Rf /root/.zypp


### PR DESCRIPTION
## Summary and Scope

The image is based on sle15 sp3, but the zypper updates were pulling from sp2 repos.  This corrects the dockerfile to point the updates to the correct repo locations for the service pack of the base image.

## Issues and Related PRs

* Resolves [CASMCMS-8006](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-8006)

## Testing
### Tested on:
  * Build system

### Test description:

This image is only used by cray-crus.  There are no systems installed with the correct required products to be able to run crus, so there is no way to test this.

## Risks and Mitigations

This is a very minor change and if it builds successfully it should be correct.

## Pull Request Checklist
- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable

