### PR TITLE
CASMTRIAGE-3526 - fix dir permissions on munge-munge image.

### DIFF
--- a/munge-munge/1.1.3/Dockerfile
+++ b/munge-munge/1.1.3/Dockerfile
@@ -21,7 +21,7 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
-FROM artifactory.algol60.net/csm-docker/stable/registry.suse.com/suse/sle15:15.3 as base
+FROM artifactory.algol60.net/csm-docker/stable/registry.suse.com/suse/sle15:15.3
 
 ARG SLES_REPO_USERNAME
 ARG SLES_REPO_PASSWORD
@@ -35,14 +35,11 @@ RUN \
   zypper --non-interactive ar ${SLES_MIRROR}/Updates/SLE-Module-HPC/15-SP3/${ARCH}/update?auth=basic sles15sp3-Module-HPC-update && \
   zypper update -y && \
   zypper install -y munge && \
-  zypper clean -a && zypper --non-interactive rr --all && rm -f /etc/zypp/repos.d/* && rm -Rf /root/.zypp
+  zypper clean -a && zypper --non-interactive rr --all && rm -f /etc/zypp/repos.d/* && rm -Rf /root/.zypp && \
+  chmod 3777 /run/munge /var/run/munge && \
+  chmod 0700 /etc/munge /var/lib/munge /var/log/munge
 
 USER munge:munge
 VOLUME /var/run/munge /etc/munge
 
-FROM base as testing
-COPY test.sh ./
-ENTRYPOINT ["./test.sh"]
-
-FROM base as app
-ENTRYPOINT ["/usr/sbin/munged", "-F"]
+ENTRYPOINT ["/usr/sbin/munged", "-F", "-f"]


### PR DESCRIPTION
## Summary and Scope

Fixing directory permissions on munge image so that the munged process can run correctly as a non-root user.

## Issues and Related PRs

* Resolves [CASMTRIAGE-3526](https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-3526)
* Change will also be needed in `cray-crus` to the helm chart to run this container under the correct user.

## Testing
### Tested on:
  * `Hela`

### Test description:

Had to create the image locally with these changes as best I could build (don't have permissions to access internal repos from my local build), then uploaded the image to Hela and tested there.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? Y
- Was upgrade tested? If not, why? N - just an image
- Was downgrade tested? If not, why? N - just an image
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

This is a low risk change as the only user of this image is cray-crus and it isn't currently working. 
## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable
