### PR TITLE
CASMPET-5697: Add oauth2-proxy v7.3.0 image

### DIFF
--- a/.github/workflows/quay.io.oauth2-proxy.oauth2-proxy.v7.3.0.yaml
+++ b/.github/workflows/quay.io.oauth2-proxy.oauth2-proxy.v7.3.0.yaml
@@ -1,0 +1,70 @@
+#
+# MIT License
+#
+# (C) Copyright [2022] Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+name: quay.io/oauth2-proxy/oauth2-proxy:v7.3.0
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - .github/workflows/quay.io.oauth2-proxy.oauth2-proxy.v7.3.0.yaml
+      - quay.io/oauth2-proxy/oauth2-proxy/v7.3.0/**
+  pull_request:
+    branches:
+      - main
+    paths:
+      - .github/workflows/quay.io.oauth2-proxy.oauth2-proxy.v7.3.0.yaml
+      - quay.io/oauth2-proxy/oauth2-proxy/v7.3.0/**
+  workflow_dispatch:
+  schedule:
+    - cron: '28 11 * * *'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      CONTEXT_PATH: quay.io/oauth2-proxy/oauth2-proxy/v7.3.0
+      DOCKER_REPO: artifactory.algol60.net/csm-docker/stable/quay.io/oauth2-proxy/oauth2-proxy
+      DOCKER_TAG: v7.3.0
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+
+      - name: build-sign-scan
+        uses: Cray-HPE/github-actions/build-sign-scan@main
+        with:
+          # Only push on main builds
+          docker_push: ${{ github.ref == 'refs/heads/main' }}
+          context_path: ${{ env.CONTEXT_PATH }}
+          docker_repo: ${{ env.DOCKER_REPO }}
+          docker_tag: ${{ env.DOCKER_TAG }}
+          artifactory_algol60_token: ${{ secrets.ARTIFACTORY_ALGOL60_TOKEN }}
+          cosign_gcp_workload_identity_provider: ${{ secrets.COSIGN_GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          cosign_gcp_service_account: ${{ secrets.COSIGN_GCP_SERVICE_ACCOUNT }}
+          cosign_key: ${{ secrets.COSIGN_KEY }}
+          snyk_token: ${{ secrets.SNYK_TOKEN }}
+          github_sha: $GITHUB_SHA

--- a/quay.io/oauth2-proxy/oauth2-proxy/v7.3.0/Dockerfile
+++ b/quay.io/oauth2-proxy/oauth2-proxy/v7.3.0/Dockerfile
@@ -1,0 +1,33 @@
+#
+# MIT License
+#
+# (C) Copyright [2022] Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+FROM quay.io/oauth2-proxy/oauth2-proxy:v7.3.0 
+
+USER root
+
+RUN apk update && \
+    apk add --upgrade apk-tools &&  \
+    apk -U upgrade && \
+    rm -rf /var/cache/apk/*
+
+USER 65532:65532


### PR DESCRIPTION
## Summary and Scope

oauth2-proxy published a new image v7.3.0 which removed the alpine image pinning. It will help us with CVE remediation.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Partially Resolves [CASMPET-5697](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-5697)
* Change will also be needed in `<insert branch name here>`
* Future work required by [CASMPET-5697](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-5697)
* Documentation changes required in [issue id](issue link)
* Merge with/before/after `<insert PR URL here>`

## Testing

Will be tested after the container image is rebuilt and published.

### Tested on:

  * `<development system>`
  * Local development environment
  * Virtual Shasta

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

Low.

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

