### PR TITLE
CASMPET-5796: use kiali user id

### DIFF
--- a/quay.io/kiali/kiali/v1.36.7/Dockerfile
+++ b/quay.io/kiali/kiali/v1.36.7/Dockerfile
@@ -22,8 +22,12 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 FROM quay.io/kiali/kiali:v1.36.7
+
 USER root
+
 RUN microdnf clean all && \
     microdnf update --nodocs && \
     microdnf clean all
-USER kiali
+
+# 1000 is kiali user id
+USER 1000


### PR DESCRIPTION
## Summary and Scope

Use the user id of kiali instead of username to prevent the unknown user error when running as non-root.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMPET-5796](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-5796)
* Future work required by [CASMPET-5796](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-5796)

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * Virtual Shasta

### Test description:

Using kiali username caused the following error:
"Error: container has runAsNonRoot and image has non-numeric user (kiali), cannot verify user is non-root"
Will validate the above error is fixed.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

Low.

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

