### PR TITLE
CASMSEC-344 use docker secrets to avoid build arg exposure in build history

### DIFF
--- a/.github/workflows/munge-munge.1.1.3.yaml
+++ b/.github/workflows/munge-munge.1.1.3.yaml
@@ -57,7 +57,7 @@ jobs:
       - name: build-sign-scan
         uses: Cray-HPE/github-actions/build-sign-scan@main
         with:
-          docker_build_args: |
+          docker_secrets: |
             SLES_REPO_USERNAME=${{ secrets.ARTIFACTORY_ALGOL60_READONLY_USERNAME }}
             SLES_REPO_PASSWORD=${{ secrets.ARTIFACTORY_ALGOL60_READONLY_TOKEN }}
           # Only push on main builds

--- a/.github/workflows/registry.suse.com.suse.sle15.15.3.yaml
+++ b/.github/workflows/registry.suse.com.suse.sle15.15.3.yaml
@@ -57,7 +57,7 @@ jobs:
       - name: build-sign-scan
         uses: Cray-HPE/github-actions/build-sign-scan@main
         with:
-          docker_build_args: |
+          docker_secrets: |
             SLES_REPO_USERNAME=${{ secrets.ARTIFACTORY_ALGOL60_READONLY_USERNAME }}
             SLES_REPO_PASSWORD=${{ secrets.ARTIFACTORY_ALGOL60_READONLY_TOKEN }}
           # Only push on main builds

--- a/.github/workflows/registry.suse.com.suse.sle15.15.4.yaml
+++ b/.github/workflows/registry.suse.com.suse.sle15.15.4.yaml
@@ -57,7 +57,7 @@ jobs:
       - name: build-sign-scan
         uses: Cray-HPE/github-actions/build-sign-scan@main
         with:
-          docker_build_args: |
+          docker_secrets: |
             SLES_REPO_USERNAME=${{ secrets.ARTIFACTORY_ALGOL60_READONLY_USERNAME }}
             SLES_REPO_PASSWORD=${{ secrets.ARTIFACTORY_ALGOL60_READONLY_TOKEN }}
           # Only push on main builds

--- a/munge-munge/1.1.3/Dockerfile
+++ b/munge-munge/1.1.3/Dockerfile
@@ -23,21 +23,8 @@
 #
 FROM artifactory.algol60.net/csm-docker/stable/registry.suse.com/suse/sle15:15.3
 
-ARG SLES_REPO_USERNAME
-ARG SLES_REPO_PASSWORD
-ARG SLES_MIRROR="https://${SLES_REPO_USERNAME}:${SLES_REPO_PASSWORD}@artifactory.algol60.net/artifactory/sles-mirror"
-ARG ARCH=x86_64
-RUN \
-  zypper --non-interactive rr --all && \
-  zypper --non-interactive ar ${SLES_MIRROR}/Products/SLE-Module-Basesystem/15-SP3/${ARCH}/product?auth=basic sles15sp3-Module-Basesystem-product && \
-  zypper --non-interactive ar ${SLES_MIRROR}/Updates/SLE-Module-Basesystem/15-SP3/${ARCH}/update?auth=basic sles15sp3-Module-Basesystem-update && \
-  zypper --non-interactive ar ${SLES_MIRROR}/Products/SLE-Module-HPC/15-SP3/${ARCH}/product?auth=basic sles15sp3-Module-HPC-product && \
-  zypper --non-interactive ar ${SLES_MIRROR}/Updates/SLE-Module-HPC/15-SP3/${ARCH}/update?auth=basic sles15sp3-Module-HPC-update && \
-  zypper update -y && \
-  zypper install -y munge && \
-  zypper clean -a && zypper --non-interactive rr --all && rm -f /etc/zypp/repos.d/* && rm -Rf /root/.zypp && \
-  chmod 3777 /run/munge /var/run/munge && \
-  chmod 0700 /etc/munge /var/lib/munge /var/log/munge
+COPY zypper.sh /
+RUN --mount=type=secret,id=SLES_REPO_USERNAME --mount=type=secret,id=SLES_REPO_PASSWORD ./zypper.sh && rm /zypper.sh
 
 USER munge:munge
 VOLUME /var/run/munge /etc/munge

--- a/munge-munge/1.1.3/zypper.sh
+++ b/munge-munge/1.1.3/zypper.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -e +xv
+trap "rm -rf /root/.zypp" EXIT
+
+SLES_REPO_USERNAME=$(cat /run/secrets/SLES_REPO_USERNAME)
+SLES_REPO_PASSWORD=$(cat /run/secrets/SLES_REPO_PASSWORD)
+SLES_MIRROR="https://${SLES_REPO_USERNAME:-}${SLES_REPO_PASSWORD+:}${SLES_REPO_PASSWORD}@artifactory.algol60.net/artifactory/sles-mirror"
+ARCH=x86_64
+zypper --non-interactive rr --all
+zypper --non-interactive ar ${SLES_MIRROR}/Products/SLE-Module-Basesystem/15-SP3/${ARCH}/product?auth=basic sles15sp3-Module-Basesystem-product
+zypper --non-interactive ar ${SLES_MIRROR}/Updates/SLE-Module-Basesystem/15-SP3/${ARCH}/update?auth=basic sles15sp3-Module-Basesystem-update
+zypper --non-interactive ar ${SLES_MIRROR}/Products/SLE-Module-HPC/15-SP3/${ARCH}/product?auth=basic sles15sp3-Module-HPC-product
+zypper --non-interactive ar ${SLES_MIRROR}/Updates/SLE-Module-HPC/15-SP3/${ARCH}/update?auth=basic sles15sp3-Module-HPC-update
+zypper update -y
+zypper install -y munge
+zypper clean -a && zypper --non-interactive rr --all && rm -f /etc/zypp/repos.d/*
+chmod 3777 /run/munge /var/run/munge
+chmod 0700 /etc/munge /var/lib/munge /var/log/munge

--- a/registry.suse.com/suse/sle15/15.3/Dockerfile
+++ b/registry.suse.com/suse/sle15/15.3/Dockerfile
@@ -23,16 +23,5 @@
 #
 FROM registry.suse.com/suse/sle15:15.3
 
-ARG SLES_REPO_USERNAME
-ARG SLES_REPO_PASSWORD
-ARG SLES_MIRROR="https://${SLES_REPO_USERNAME}:${SLES_REPO_PASSWORD}@artifactory.algol60.net/artifactory/sles-mirror"
-ARG ARCH=x86_64
-RUN \
-  zypper --non-interactive rr --all && \
-  zypper --non-interactive ar ${SLES_MIRROR}/Products/SLE-Module-Basesystem/15-SP3/${ARCH}/product?auth=basic sles15sp3-Module-Basesystem-product && \
-  zypper --non-interactive ar ${SLES_MIRROR}/Updates/SLE-Module-Basesystem/15-SP3/${ARCH}/update?auth=basic sles15sp3-Module-Basesystem-update && \
-  zypper update -y && \
-  zypper clean -a && \
-  zypper --non-interactive rr --all && \
-  rm -f /etc/zypp/repos.d/* && \
-  rm -Rf /root/.zypp
+COPY zypper.sh /
+RUN --mount=type=secret,id=SLES_REPO_USERNAME --mount=type=secret,id=SLES_REPO_PASSWORD ./zypper.sh && rm /zypper.sh

--- a/registry.suse.com/suse/sle15/15.3/zypper.sh
+++ b/registry.suse.com/suse/sle15/15.3/zypper.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -e +xv
+trap "rm -rf /root/.zypp" EXIT
+
+SLES_REPO_USERNAME=$(cat /run/secrets/SLES_REPO_USERNAME)
+SLES_REPO_PASSWORD=$(cat /run/secrets/SLES_REPO_PASSWORD)
+SLES_MIRROR="https://${SLES_REPO_USERNAME:-}${SLES_REPO_PASSWORD+:}${SLES_REPO_PASSWORD}@artifactory.algol60.net/artifactory/sles-mirror"
+ARCH=x86_64
+zypper --non-interactive rr --all
+zypper --non-interactive ar ${SLES_MIRROR}/Products/SLE-Module-Basesystem/15-SP3/${ARCH}/product?auth=basic sles15sp3-Module-Basesystem-product
+zypper --non-interactive ar ${SLES_MIRROR}/Updates/SLE-Module-Basesystem/15-SP3/${ARCH}/update?auth=basic sles15sp3-Module-Basesystem-update
+zypper update -y
+zypper clean -a
+zypper --non-interactive rr --all
+rm -f /etc/zypp/repos.d/*

--- a/registry.suse.com/suse/sle15/15.4/Dockerfile
+++ b/registry.suse.com/suse/sle15/15.4/Dockerfile
@@ -23,16 +23,5 @@
 #
 FROM registry.suse.com/suse/sle15:15.4
 
-ARG SLES_REPO_USERNAME
-ARG SLES_REPO_PASSWORD
-ARG SLES_MIRROR="https://${SLES_REPO_USERNAME}:${SLES_REPO_PASSWORD}@artifactory.algol60.net/artifactory/sles-mirror"
-ARG ARCH=x86_64
-RUN \
-  zypper --non-interactive rr --all && \
-  zypper --non-interactive ar ${SLES_MIRROR}/Products/SLE-Module-Basesystem/15-SP4/${ARCH}/product?auth=basic sles15sp4-Module-Basesystem-product && \
-  zypper --non-interactive ar ${SLES_MIRROR}/Updates/SLE-Module-Basesystem/15-SP4/${ARCH}/update?auth=basic sles15sp4-Module-Basesystem-update && \
-  zypper update -y && \
-  zypper clean -a && \
-  zypper --non-interactive rr --all && \
-  rm -f /etc/zypp/repos.d/* && \
-  rm -Rf /root/.zypp
+COPY zypper.sh /
+RUN --mount=type=secret,id=SLES_REPO_USERNAME --mount=type=secret,id=SLES_REPO_PASSWORD ./zypper.sh && rm /zypper.sh

--- a/registry.suse.com/suse/sle15/15.4/zypper.sh
+++ b/registry.suse.com/suse/sle15/15.4/zypper.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -e +xv
+trap "rm -rf /root/.zypp" EXIT
+
+SLES_REPO_USERNAME=$(cat /run/secrets/SLES_REPO_USERNAME)
+SLES_REPO_PASSWORD=$(cat /run/secrets/SLES_REPO_PASSWORD)
+SLES_MIRROR="https://${SLES_REPO_USERNAME:-}${SLES_REPO_PASSWORD+:}${SLES_REPO_PASSWORD}@artifactory.algol60.net/artifactory/sles-mirror"
+ARCH=x86_64
+zypper --non-interactive rr --all
+zypper --non-interactive ar ${SLES_MIRROR}/Products/SLE-Module-Basesystem/15-SP4/${ARCH}/product?auth=basic sles15sp4-Module-Basesystem-product
+zypper --non-interactive ar ${SLES_MIRROR}/Updates/SLE-Module-Basesystem/15-SP4/${ARCH}/update?auth=basic sles15sp4-Module-Basesystem-update
+zypper update -y
+zypper clean -a
+zypper --non-interactive rr --all
+rm -f /etc/zypp/repos.d/*


### PR DESCRIPTION
## Summary and Scope

Use docker buildkit secrets to propagate `SLES_REPO_USERNAME` and `SLES_REPO_PASSWORD` into docker build contexts.

## Issues and Related PRs

* Resolves [CASMSEC-344](https://jira-pro.its.hpecorp.net:8443/browse/CASMSEC-344)

## Testing
### Tested on:

  * Local development environment
  * Github

### Test description:

Tested locally to ensure that secrets are injected successfully into build, and not recorded in image history:

    $ docker build . --secret id=SLES_REPO_PASSWORD,src=SLES_REPO_PASSWORD --secret id=SLES_REPO_USERNAME,src=SLES_REPO_USERNAME --no-cache -t artifactory.algol60.net/csm-docker/stable/registry.suse.com/suse/sle15:15.4
    #1 [internal] load build definition from Dockerfile
    #1 sha256:c1a15af486ece7b9a035751780e8fd166f90819f96f9b61580c56c90ccf91c87
    #1 transferring dockerfile: 37B done
    #1 DONE 0.0s
    ...
    #8 exporting to image
    #8 sha256:e8c613e07b0b7ff33893b694f7759a10d42e180f2b4dc349fb57dc6b71dcab00
    #8 exporting layers 0.0s done
    #8 writing image sha256:537c6c20a82f91eb5e602aae3cf609ab348476797280f6cbfc3f5b936a4e544d done
    #8 naming to artifactory.algol60.net/csm-docker/stable/registry.suse.com/suse/sle15:15.4 done
    #8 DONE 0.0s
    
    $ docker history artifactory.algol60.net/csm-docker/stable/registry.suse.com/suse/sle15:15.4 --no-trunc
    IMAGE                                                                     CREATED          CREATED BY                                               SIZE      COMMENT
    sha256:537c6c20a82f91eb5e602aae3cf609ab348476797280f6cbfc3f5b936a4e544d   3 seconds ago    RUN /bin/sh -c ./zypper.sh && rm /zypper.sh # buildkit   2.18MB    buildkit.dockerfile.v0
    <missing>                                                                 12 seconds ago   COPY zypper.sh / # buildkit                              732B      buildkit.dockerfile.v0
    <missing>                                                                 6 days ago       KIWI 9.24.17                                             122MB


Tested on feature branch in Github to ensure that docker secrets are properly supported by updated `build-sign-can` github action:
https://github.com/Cray-HPE/container-images/actions/runs/2828262133

## Risks and Mitigations
Low - backwards compatible change in build pipeline.
