### PR TITLE
CASMMON-195 Upgrade to 8.x

### DIFF
--- a/.github/workflows/docker.io.grafana.grafana.8.5.9.yaml
+++ b/.github/workflows/docker.io.grafana.grafana.8.5.9.yaml
@@ -1,0 +1,70 @@
+#
+# MIT License
+#
+# (C) Copyright [2022] Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+name: docker.io/grafana/grafana:8.5.9
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - .github/workflows/docker.io.grafana.grafana.8.5.9.yaml
+      - docker.io/grafana/grafana/8.5.9/**
+  pull_request:
+    branches:
+      - main
+    paths:
+      - .github/workflows/docker.io.grafana.grafana.8.5.9.yaml
+      - docker.io/grafana/grafana/8.5.9/**
+  workflow_dispatch:
+  schedule:
+    - cron: '18 3 * * *'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      CONTEXT_PATH: docker.io/grafana/grafana/8.5.9
+      DOCKER_REPO: artifactory.algol60.net/csm-docker/stable/docker.io/grafana/grafana
+      DOCKER_TAG: 8.5.9
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+
+      - name: build-sign-scan
+        uses: Cray-HPE/github-actions/build-sign-scan@main
+        with:
+          # Only push on main builds
+          docker_push: ${{ github.ref == 'refs/heads/main' }}
+          context_path: ${{ env.CONTEXT_PATH }}
+          docker_repo: ${{ env.DOCKER_REPO }}
+          docker_tag: ${{ env.DOCKER_TAG }}
+          artifactory_algol60_token: ${{ secrets.ARTIFACTORY_ALGOL60_TOKEN }}
+          cosign_gcp_workload_identity_provider: ${{ secrets.COSIGN_GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          cosign_gcp_service_account: ${{ secrets.COSIGN_GCP_SERVICE_ACCOUNT }}
+          cosign_key: ${{ secrets.COSIGN_KEY }}
+          snyk_token: $\{{ secrets.SNYK_TOKEN }}
+          github_sha: $GITHUB_SHA

--- a/docker.io/grafana/grafana/8.5.9/Dockerfile
+++ b/docker.io/grafana/grafana/8.5.9/Dockerfile
@@ -1,0 +1,32 @@
+#
+# MIT License
+#
+# (C) Copyright [2022] Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+FROM docker.io/grafana/grafana:8.5.9
+
+USER root
+
+RUN apk add --upgrade apk-tools && \
+    apk update && apk -U upgrade && \
+    rm -rf /var/cache/apk/*
+
+USER grafana


### PR DESCRIPTION
Upgrade Grafana to 8.5.9 aligned with SMF. Grafana Upgrade and Dashboard improvements by supporting new visualizations.
Support new visualization elements such as pie charts. This change is backward compatible.

Resolves - 
[CASMMON-195](https://jira-pro.its.hpecorp.net:8443/browse/CASMMON-195)
Epic Name: Grafana Upgrade and Dashboard improvements by supporting new visualizations

Upgrade grafana to 7.5.11 version to support merge transform operator in grafana dashboard while merging multiple promsql queries for switch metrics to create grafana dashboard.

Future work required - 
[CASMMON-196](https://jira-pro.its.hpecorp.net:8443/browse/CASMMON-196)	
[Use pie chart panel in the existing dashboards](https://jira-pro.its.hpecorp.net:8443/browse/CASMMON-196)

Version number(s) incremented from 7.0.5 to 8.5.9
Copyrights updated
License file intact
Target branch correct
CHANGELOG.md updated
Testing is appropriate and complete, if applicable