### PR TITLE
Add gitea image to 1.17.2

### DIFF
--- a/docker.io/gitea/gitea/1.17.2-rootless/Dockerfile
+++ b/docker.io/gitea/gitea/1.17.2-rootless/Dockerfile
@@ -1,0 +1,35 @@
+#
+# MIT License
+#
+# (C) Copyright [2022] Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+FROM docker.io/gitea/gitea:1.17.2-rootless
+
+# In order to run apk, we must change to the root user
+USER root
+RUN apk add --upgrade apk-tools &&  \
+    apk update && apk -U upgrade && \
+    rm -rf /var/cache/apk/*
+
+# NOTE: USER 1000:1000 is the user specified in the Dockerfile for the
+# docker.io/gitea/gitea:1.16.4-rootless build found here:
+# https://hub.docker.com/layers/gitea/gitea/1.16.4-rootless/images/sha256-f08e7e450c02d17c08da2b5cb7b2742d520bc3bfe80749e5600b3fa3e95d15b2?context=explore
+USER 1000:1000


### PR DESCRIPTION
## Summary and Scope

Adds a new rootless gitea image for 1.17.2 to address CVE issues.

## Issues and Related PRs

* Related to CASMCMS-8251

## Testing

Testing will come once the image is built and before we update the gitea chart to use this new image.

