### PR TITLE
CASMCMS-8288: revert sles15sp4 update in the munge-munge container.

### DIFF
--- a/munge-munge/1.1.3/Dockerfile
+++ b/munge-munge/1.1.3/Dockerfile
@@ -21,7 +21,7 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
-FROM artifactory.algol60.net/csm-docker/stable/registry.suse.com/suse/sle15:15.4
+FROM artifactory.algol60.net/csm-docker/stable/registry.suse.com/suse/sle15:15.3
 
 COPY zypper.sh /
 RUN --mount=type=secret,id=SLES_REPO_USERNAME --mount=type=secret,id=SLES_REPO_PASSWORD ./zypper.sh && rm /zypper.sh


### PR DESCRIPTION
## Summary and Scope

The change to sp4 as the base image changed the user id of the 'munge' user and broke the security context settings of the helm charts using the image. This reverts that change.
 
## Issues and Related PRs
* Resolves [CASMCMS-8288](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-8288)

## Testing
### Test description:

Can't really test until the new image is built - then will verify correct user ID again.

## Risks and Mitigations

Low risk, broken now and just reverting a change.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct

