### PR TITLE
CASMMON-233 Cluster-view-panel uninstall

### DIFF
--- a/docker.io/grafana/grafana/8.5.9/Dockerfile
+++ b/docker.io/grafana/grafana/8.5.9/Dockerfile
@@ -42,15 +42,4 @@ RUN wget -nv https://grafana.com/api/plugins/vonage-status-panel/versions/latest
 RUN unzip /var/lib/grafana-plugins/vonage-status-panel-1.0.11.zip -d /var/lib/grafana-plugins/
 RUN rm -rf /var/lib/grafana-plugins/vonage-status-panel-1.0.11.zip
 
-#Clusterview-panel
-RUN mkdir /var/lib/grafana-plugins/hpe-grafana-clusterview-panel
-COPY ./hpe-grafana-clusterview-panel /var/lib/grafana-plugins/hpe-grafana-clusterview-panel
-WORKDIR /var/lib/grafana-plugins/hpe-grafana-clusterview-panel/hpe-clusterview-panel
-RUN npm install -g yarn \
-&& yarn install \
-&& yarn dev \
-&& mv dist hpe-clusterview-panel \
-&& mv hpe-clusterview-panel /var/lib/grafana-plugins/ \
-&& rm -rf /var/lib/grafana-plugins/hpe-grafana-clusterview-panel
-
 USER grafana

--- a/docker.io/grafana/grafana/8.5.9/runBuildPrep.sh
+++ b/docker.io/grafana/grafana/8.5.9/runBuildPrep.sh
@@ -1,3 +1,0 @@
-#!/bin/bash -x
-
-git clone https://$HPE_GITHUB_TOKEN@github.hpe.com/HPC-DEV/hpe-grafana-clusterview-panel


### PR DESCRIPTION
## Summary and Scope
CASMMON-233 Cluster-view-panel uninstall as files are hosted on the private repo.

## Issues and Related PRs
Cluster-view-panel implementation for CASM is pushed till further notice and requirement.

* Resolves [issue id] -
Run failed: docker.io/grafana/grafana:8.5.9 - main (56cb307)

Changes:
Removing the pre-build script as it is not cloning the source code of the cluster view panel from the private repo.
Updated the dockerfile to remove the plugin from the source code.

Testing:
Grafana Startup

### Tested on:
Slice and CVM.

### Test description:
- Was downgrade tested? Yes.