### PR TITLE
CASMMON-249: Update the grok-exporter image from version 2 to version 3.

### DIFF
--- a/docker.io/grok-exporter/grok-exporter/latest/Dockerfile
+++ b/docker.io/grok-exporter/grok-exporter/latest/Dockerfile
@@ -1,1 +1,1 @@
-FROM docker.io/palobo/grok_exporter:latest
+FROM docker.io/alighufron/grok_exporter:latest


### PR DESCRIPTION
## Summary and Scope

_Summarize what has changed. Explain why this PR is necessary. What is impacted? Is this a new feature, critical bug fix, etc?_

CASMMON-249: Update the grok-exporter image from version 2 to version 3.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves: https://jira-pro.its.hpecorp.net:8443/browse/CASMMON-249

## Test

Craystack VM and Slice

shreni:~ # docker images | grep grok
artifactory.algol60.net/csm-docker/unstable/docker.io/grok-exporter/grok-exporter              latest    616ef98a1fef   4 years ago    149MB

shreni:~ # docker ps | grep grok
603c0f742e41   artifactory.algol60.net/csm-docker/unstable/docker.io/grok-exporter/grok-exporter   "./grok_exporter -co…"   About a minute ago   Up About a minute   0.0.0.0:8003->9144/tcp, :::8003->9144/tcp   grok-shreni-01

shreni:~ # curl localhost:8003/metrics
#HELP alex_install_command_log_stage_one_two_three_four count of commands that say stage.1.2.3.4.10
#TYPE alex_install_command_log_stage_one_two_three_four counter
alex_install_command_log_stage_one_two_three_four 0
#HELP go_gc_duration_seconds A summary of the GC invocation durations.
#TYPE go_gc_duration_seconds summary
go_gc_duration_seconds{quantile="0"} 6.716e-06
go_gc_duration_seconds{quantile="0.25"} 2.3615e-05
go_gc_duration_seconds{quantile="0.5"} 2.5549e-05
go_gc_duration_seconds{quantile="0.75"} 2.784e-05
go_gc_duration_seconds{quantile="1"} 9.7744e-05
go_gc_duration_seconds_sum 0.000847767
go_gc_duration_seconds_count 28
#HELP go_goroutines Number of goroutines that currently exist.
#TYPE go_goroutines gauge
go_goroutines 28