### PR TITLE
CASMPET-6198:  Don't fail cilium, json-mock, and multus builds on snyk errors

### DIFF
--- a/.github/workflows/ghcr.io.k8snetworkplumbingwg.multus-cni.v3.9.1.yaml
+++ b/.github/workflows/ghcr.io.k8snetworkplumbingwg.multus-cni.v3.9.1.yaml
@@ -55,4 +55,4 @@ jobs:
           cosign_key: ${{ secrets.COSIGN_KEY }}
           snyk_token: ${{ secrets.SNYK_TOKEN }}
           github_sha: $GITHUB_SHA
-          fail_on_snyk_errors: true
+          fail_on_snyk_errors: false

--- a/.github/workflows/ghcr.io.k8snetworkplumbingwg.multus-cni.v3.9.yaml
+++ b/.github/workflows/ghcr.io.k8snetworkplumbingwg.multus-cni.v3.9.yaml
@@ -55,4 +55,4 @@ jobs:
           cosign_key: ${{ secrets.COSIGN_KEY }}
           snyk_token: ${{ secrets.SNYK_TOKEN }}
           github_sha: $GITHUB_SHA
-          fail_on_snyk_errors: true
+          fail_on_snyk_errors: false

--- a/.github/workflows/quay.io.cilium.cilium.v1.11.6.yaml
+++ b/.github/workflows/quay.io.cilium.cilium.v1.11.6.yaml
@@ -55,4 +55,4 @@ jobs:
           cosign_key: ${{ secrets.COSIGN_KEY }}
           snyk_token: ${{ secrets.SNYK_TOKEN }}
           github_sha: $GITHUB_SHA
-          fail_on_snyk_errors: true
+          fail_on_snyk_errors: false

--- a/.github/workflows/quay.io.cilium.cilium.v1.12.0.yaml
+++ b/.github/workflows/quay.io.cilium.cilium.v1.12.0.yaml
@@ -55,4 +55,4 @@ jobs:
           cosign_key: ${{ secrets.COSIGN_KEY }}
           snyk_token: ${{ secrets.SNYK_TOKEN }}
           github_sha: $GITHUB_SHA
-          fail_on_snyk_errors: true
+          fail_on_snyk_errors: false

--- a/.github/workflows/quay.io.cilium.cilium.v1.12.2.yaml
+++ b/.github/workflows/quay.io.cilium.cilium.v1.12.2.yaml
@@ -55,4 +55,4 @@ jobs:
           cosign_key: ${{ secrets.COSIGN_KEY }}
           snyk_token: ${{ secrets.SNYK_TOKEN }}
           github_sha: $GITHUB_SHA
-          fail_on_snyk_errors: true
+          fail_on_snyk_errors: false

--- a/.github/workflows/quay.io.cilium.cilium.v1.12.3.yaml
+++ b/.github/workflows/quay.io.cilium.cilium.v1.12.3.yaml
@@ -57,4 +57,4 @@ jobs:
           cosign_key: ${{ secrets.COSIGN_KEY }}
           snyk_token: ${{ secrets.SNYK_TOKEN }}
           github_sha: $GITHUB_SHA
-          fail_on_snyk_errors: true
+          fail_on_snyk_errors: false

--- a/.github/workflows/quay.io.cilium.json-mock.v1.3.0.yaml
+++ b/.github/workflows/quay.io.cilium.json-mock.v1.3.0.yaml
@@ -57,4 +57,4 @@ jobs:
           cosign_key: ${{ secrets.COSIGN_KEY }}
           snyk_token: ${{ secrets.SNYK_TOKEN }}
           github_sha: $GITHUB_SHA
-          fail_on_snyk_errors: true
+          fail_on_snyk_errors: false


### PR DESCRIPTION
## Summary and Scope

After an error in the shared workflow was fixed, a few of the cilium images started to hit failures.   These are upstream images so I set the fail_on_snyk_error to false as recommended to suppress the error.   I also took care of the same thing on a couple of the multus container images.

## Issues and Related PRs

* Resolves [CASMPET-6198](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-6198)

## Testing

Verified no failure in the branch build.


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

