### PR TITLE
CASMINST-5476: Updated `fail_on_snyk_errors: false` on postgres-operator upstream images

### DIFF
--- a/.github/workflows/registry.opensource.zalan.do.acid.logical-backup.v1.8.2.yaml
+++ b/.github/workflows/registry.opensource.zalan.do.acid.logical-backup.v1.8.2.yaml
@@ -57,4 +57,4 @@ jobs:
           cosign_key: ${{ secrets.COSIGN_KEY }}
           snyk_token: ${{ secrets.SNYK_TOKEN }}
           github_sha: $GITHUB_SHA
-          fail_on_snyk_errors: true
+          fail_on_snyk_errors: false  # upstream image

--- a/.github/workflows/registry.opensource.zalan.do.acid.pgbouncer.master-22.yaml
+++ b/.github/workflows/registry.opensource.zalan.do.acid.pgbouncer.master-22.yaml
@@ -55,4 +55,4 @@ jobs:
           cosign_key: ${{ secrets.COSIGN_KEY }}
           snyk_token: ${{ secrets.SNYK_TOKEN }}
           github_sha: $GITHUB_SHA
-          fail_on_snyk_errors: true
+          fail_on_snyk_errors: false  # upstream image

--- a/.github/workflows/registry.opensource.zalan.do.acid.postgres-operator.v1.8.2.yaml
+++ b/.github/workflows/registry.opensource.zalan.do.acid.postgres-operator.v1.8.2.yaml
@@ -55,4 +55,4 @@ jobs:
           cosign_key: ${{ secrets.COSIGN_KEY }}
           snyk_token: ${{ secrets.SNYK_TOKEN }}
           github_sha: $GITHUB_SHA
-          fail_on_snyk_errors: true
+          fail_on_snyk_errors: false  # upstream image

--- a/.github/workflows/registry.opensource.zalan.do.acid.spilo-14.2.1-p7.yaml
+++ b/.github/workflows/registry.opensource.zalan.do.acid.spilo-14.2.1-p7.yaml
@@ -57,4 +57,4 @@ jobs:
           cosign_key: ${{ secrets.COSIGN_KEY }}
           snyk_token: ${{ secrets.SNYK_TOKEN }}
           github_sha: $GITHUB_SHA
-          fail_on_snyk_errors: true
+          fail_on_snyk_errors: false  # upstream image


### PR DESCRIPTION
## Summary and Scope

These are upstream images so I set the fail_on_snyk_error to false as recommended to suppress the error. These all relate to upstream images used by the latest postgres-operator.
* logical-backup.v.1.8.2
* postgres-operator.v1.8.2
* pgbouncer.master-22
* spilo-14.2.1-p7

## Issues and Related PRs

* Resolves [CASMPET-5476](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-5476) partially

## Testing

Verified on branch build.


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable
