### PR TITLE
Fix docker repo path for boto3 image

### DIFF
--- a/.github/workflows/docker.io.demisto.boto3py3.kubectl_v1_21_12_1.0.0.43797.yaml
+++ b/.github/workflows/docker.io.demisto.boto3py3.kubectl_v1_21_12_1.0.0.43797.yaml
@@ -37,7 +37,7 @@ jobs:
       id-token: write
     env:
       CONTEXT_PATH: docker.io/demisto/boto3py3/kubectl_v1_21_12_1.0.0.43797
-      DOCKER_REPO: artifactory.algol60.net/docker.io/demisto/boto3py3
+      DOCKER_REPO: artifactory.algol60.net/csm-docker/stable/docker.io/demisto/boto3py3
       DOCKER_TAG: kubectl_v1_21_12_1.0.0.43797
     steps:
       - name: Checkout repo


### PR DESCRIPTION
## Summary and Scope

Updating to more recent boto3 package, and include a version that also includes kubectl.

## Issues and Related PRs

* Resolves [CASMPET-6186](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-6186)

## Testing

```
ncn-m001-e2e75ea1:/home/bklein # kubectl logs -n services $pod post-upgrade-get-snapshot
Waiting for aws credentials to appear...
cluster: cray-bos, key: cray-bos/etcd_migration.snapshot.db, file: /snapshot/snapshot.db
```

```
ncn-m001-e2e75ea1:/home/bklein # kubectl logs -n services $pod post-upgrade-restore-snapshot -f
Waiting for snapshot to appear...
Waiting for snapshot to appear...
statefulset.apps/cray-bos-bitnami-etcd scaled
Waiting for statefulset spec update to be observed...
statefulset rolling update complete 0 pods at revision cray-bos-bitnami-etcd-65c99fc7b...
cluster: cray-bos pvc: data-cray-bos-bitnami-etcd, ns: services
persistentvolumeclaim "data-cray-bos-bitnami-etcd-0" deleted
persistentvolumeclaim "data-cray-bos-bitnami-etcd-1" deleted
persistentvolumeclaim "data-cray-bos-bitnami-etcd-2" deleted
statefulset.apps/cray-bos-bitnami-etcd env updated
statefulset.apps/cray-bos-bitnami-etcd scaled
Waiting for statefulset spec update to be observed...
Waiting for 3 pods to be ready...
Waiting for 2 pods to be ready...
Waiting for 1 pods to be ready...
statefulset rolling update complete 3 pods at revision cray-bos-bitnami-etcd-5c986bddbc...
```
### Tested on:

  * Virtual Shasta

### Test description:

Pushed image to gcp, ran upgrade code with the image

## Risks and Mitigations

Low

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable