### PR TITLE
CASMPET-6311 Add opa 0.48.0 containers

### DIFF
--- a/.github/workflows/docker.io.openpolicyagent.opa.0.48.0-envoy.yaml
+++ b/.github/workflows/docker.io.openpolicyagent.opa.0.48.0-envoy.yaml
@@ -1,0 +1,57 @@
+#
+# MIT License
+#
+# (C) Copyright [2022] Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+name: docker.io/openpolicyagent/opa:0.48.0-envoy
+on:
+  push:
+    paths:
+      - .github/workflows/docker.io.openpolicyagent.opa.0.48.0-envoy.yaml
+      - docker.io/openpolicyagent/opa/0.48.0-envoy/**
+  workflow_dispatch:
+  schedule:
+    - cron: "40 3 * * *"
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      CONTEXT_PATH: docker.io/openpolicyagent/opa/0.48.0-envoy
+      DOCKER_REPO: artifactory.algol60.net/csm-docker/stable/docker.io/openpolicyagent/opa
+      DOCKER_TAG: 0.48.0-envoy
+    steps:
+      - name: build-sign-scan
+        uses: Cray-HPE/github-actions/build-sign-scan@main
+        with:
+          # Only push on main builds
+          docker_push: ${{ github.ref == 'refs/heads/main' }}
+          context_path: ${{ env.CONTEXT_PATH }}
+          docker_repo: ${{ env.DOCKER_REPO }}
+          docker_tag: ${{ env.DOCKER_TAG }}
+          artifactory_algol60_token: ${{ secrets.ARTIFACTORY_ALGOL60_TOKEN }}
+          cosign_gcp_workload_identity_provider: ${{ secrets.COSIGN_GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          cosign_gcp_service_account: ${{ secrets.COSIGN_GCP_SERVICE_ACCOUNT }}
+          cosign_key: ${{ secrets.COSIGN_KEY }}
+          snyk_token: ${{ secrets.SNYK_TOKEN }}
+          github_sha: $GITHUB_SHA

--- a/.github/workflows/docker.io.openpolicyagent.opa.0.48.0-envoy.yaml
+++ b/.github/workflows/docker.io.openpolicyagent.opa.0.48.0-envoy.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright [2022] Hewlett Packard Enterprise Development LP
+# (C) Copyright [2023] Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),

--- a/docker.io/openpolicyagent/opa/0.48.0-envoy/Dockerfile
+++ b/docker.io/openpolicyagent/opa/0.48.0-envoy/Dockerfile
@@ -1,0 +1,34 @@
+#
+# MIT License
+#
+# (C) Copyright [2022] Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+FROM golang:1.18-buster as builder
+RUN git clone https://github.com/open-policy-agent/opa-envoy-plugin /opt/opa-envoy-plugin\
+  && cd /opt/opa-envoy-plugin\
+  && git checkout v0.48.0-envoy\
+  && WASM_ENABLED=0 CGO_ENABLED=0 make
+
+FROM gcr.io/distroless/static
+COPY --from=builder /opt/opa-envoy-plugin/opa_envoy_linux_amd64 /app/opa_envoy_linux_amd64
+WORKDIR /app
+ENTRYPOINT ["./opa_envoy_linux_amd64"]
+CMD ["run"]

--- a/docker.io/openpolicyagent/opa/0.48.0-envoy/Dockerfile
+++ b/docker.io/openpolicyagent/opa/0.48.0-envoy/Dockerfile
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright [2022] Hewlett Packard Enterprise Development LP
+# (C) Copyright [2023] Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),


### PR DESCRIPTION
This adds the opa 0.48.0-envoy containers for use with cray-opa.