### PR TITLE
CASMMON-267 Upgrade prometheus-operator image

### DIFF
--- a/.github/workflows/docker.io.bitnami.prometheus-operator.v0.63.0.yaml
+++ b/.github/workflows/docker.io.bitnami.prometheus-operator.v0.63.0.yaml
@@ -21,15 +21,15 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
-name: docker.io/prom/prometheus-config-reloader:v0.62.0
+name: docker.io/bitnami/prometheus-operator:v0.63.0
 on:
   push:
     paths:
-      - .github/workflows/docker.io.prom.prometheus-config-reloader.v0.62.0.yaml
-      - docker.io/prom/prometheus-config-reloader/v0.62.0/**
+      - .github/workflows/docker.io.bitnami.prometheus-operator.v0.63.0.yaml
+      - docker.io/bitnami/prometheus-operator/v0.63.0/**
   workflow_dispatch:
   schedule:
-    - cron: '5 3 * * *'
+    - cron: '33 20 * * *'
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -37,9 +37,9 @@ jobs:
       contents: read
       id-token: write
     env:
-      CONTEXT_PATH: docker.io/prom/prometheus-config-reloader/v0.62.0
-      DOCKER_REPO: artifactory.algol60.net/csm-docker/stable/docker.io/prom/prometheus-config-reloader
-      DOCKER_TAG: v0.62.0
+      CONTEXT_PATH: docker.io/bitnami/prometheus-operator/v0.63.0
+      DOCKER_REPO: artifactory.algol60.net/csm-docker/stable/docker.io/bitnami/prometheus-operator
+      DOCKER_TAG: v0.63.0
     steps:
       - name: build-sign-scan
         uses: Cray-HPE/github-actions/build-sign-scan@main

--- a/.github/workflows/docker.io.grafana.grafana.9.3.2.yaml
+++ b/.github/workflows/docker.io.grafana.grafana.9.3.2.yaml
@@ -45,7 +45,7 @@ jobs:
         uses: Cray-HPE/github-actions/build-sign-scan@main
         with:
           # Only push on main builds
-          docker_push: true
+          docker_push: ${{ github.ref == 'refs/heads/main' }}
           context_path: ${{ env.CONTEXT_PATH }}
           docker_repo: ${{ env.DOCKER_REPO }}
           docker_tag: ${{ env.DOCKER_TAG }}

--- a/docker.io/bitnami/prometheus-operator/v0.63.0/Dockerfile
+++ b/docker.io/bitnami/prometheus-operator/v0.63.0/Dockerfile
@@ -1,0 +1,24 @@
+#
+# MIT License
+#
+# (C) Copyright [2022] Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+FROM docker.io/bitnami/prometheus-operator:0.63.0


### PR DESCRIPTION
## Summary and Scope

_Upgrade prometheus-operator to version v0.63.0 and fix workflows of last PRs_

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMMON-267](https://jira-pro.its.hpecorp.net:8443/browse/CASMMON-267)

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * `hela`
  * Local development environment
  * Virtual Shasta

### Test description:

- Was upgrade tested? Yes

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] Testing is appropriate and complete, if applicable