### PR TITLE
CASMPET-6372 1.4 : Overwrite the pgq_ticker.ini file in the postgres container due to change in pgqd:3.5-1 in spilo-12

### DIFF
--- a/registry.opensource.zalan.do/acid/spilo-12/1.6-p3/Dockerfile
+++ b/registry.opensource.zalan.do/acid/spilo-12/1.6-p3/Dockerfile
@@ -31,3 +31,11 @@ RUN apt-get update && \
     sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen \
     && dpkg-reconfigure --frontend=noninteractive locales \
     && update-locale LANG=en_US.UTF-8
+
+# Overwrite the pgq_ticker.ini file in the postgres container due to change in pgqd:3.5-1
+# https://github.com/zalando/spilo/issues/838
+RUN mkdir /root/log /root/pid
+COPY ./pgq_ticker.ini /home/postgres/pgq_ticker.ini
+
+# Capture psql version and packages to the build logs
+RUN psql --version && dpkg -l

--- a/registry.opensource.zalan.do/acid/spilo-12/1.6-p3/pgq_ticker.ini
+++ b/registry.opensource.zalan.do/acid/spilo-12/1.6-p3/pgq_ticker.ini
@@ -1,0 +1,10 @@
+[pgqd]
+initial_database = postgres
+
+# how often to do maintentance, in seconds.
+maint_period = 600
+# how often to run ticker, in seconds.
+ticker_period = 60
+
+logfile = ~/log/pgqd.log
+pidfile = ~/pid/pgqd.pid


### PR DESCRIPTION
## Summary and Scope
With the latest nightly rebuild of the spilo-12.1.6-p3 image, the pgqd package was updated from 3.3-5 to 3.5.1.
That change resulted in deprecation of some of the config values in the /home/postgres/pgq_ticker.ini file.
This fix overwrites the pgq_ticker.ini file in the postgres container due to change in pgqd:3.5-1.
This fix will allow for the image ([spilo-12.1.6-p3.yaml](https://github.com/Cray-HPE/container-images/actions/workflows/registry.opensource.zalan.do.acid.spilo-12.1.6-p3.yaml) to be rebuilt with all the latest packages such that the CSM 1.4 postgres clusters can then pick up the change.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMPET-6372](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-6372)
* Change will also be needed in NA
* Future work required by NA
* Documentation changes required in NA
* Merge with/before/after NA

## Testing

### Tested on:

* local docker build environment

### Test description:

Verified that the new file is in place and that the `pgqd pgq_ticker.ini` does not fail reading the config
```
root@10bf949122df:/home/postgres# ls
etc  pgq_ticker.ini  postgres.yml
root@10bf949122df:/home/postgres# cat pgq_ticker.ini
[pgqd]
initial_database = postgres

# how often to do maintentance, in seconds.
maint_period = 600
# how often to run ticker, in seconds.
ticker_period = 60

logfile = ~/log/pgqd.log
pidfile = ~/pid/pgqd.pid

root@10bf949122df:/home/postgres# pgqd pgq_ticker.ini
2023-03-03 16:21:36.875 UTC [16] LOG Starting pgqd 3.5
2023-03-03 16:21:36.875 UTC [16] LOG auto-detecting dbs ...
...
```

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

Low

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

