### PR TITLE
CAMSPET-6373 1.5 : Overwrite the pgq_ticker.ini file in the postgres container due to change in pgqd:3.5-1 in spilo-14

### DIFF
--- a/registry.opensource.zalan.do/acid/spilo-14/2.1-p7/Dockerfile
+++ b/registry.opensource.zalan.do/acid/spilo-14/2.1-p7/Dockerfile
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright [2022] Hewlett Packard Enterprise Development LP
+# (C) Copyright [2022-2023] Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -25,3 +25,11 @@ FROM registry.opensource.zalan.do/acid/spilo-14:2.1-p7
 
 RUN apt-get -y update && apt-get upgrade -y && apt full-upgrade -y\
     && rm -rf /var/lib/apt/lists/
+
+# Overwrite the pgq_ticker.ini file in the postgres container due to change in pgqd:3.5-1
+# https://github.com/zalando/spilo/issues/838
+RUN mkdir /root/log /root/pid
+COPY ./pgq_ticker.ini /home/postgres/pgq_ticker.ini
+
+# Capture psql version and packages to the build logs
+RUN psql --version && dpkg -l

--- a/registry.opensource.zalan.do/acid/spilo-14/2.1-p7/pgq_ticker.ini
+++ b/registry.opensource.zalan.do/acid/spilo-14/2.1-p7/pgq_ticker.ini
@@ -1,0 +1,10 @@
+[pgqd]
+initial_database = postgres
+
+# how often to do maintentance, in seconds.
+maint_period = 600
+# how often to run ticker, in seconds.
+ticker_period = 60
+
+logfile = ~/log/pgqd.log
+pidfile = ~/pid/pgqd.pid


### PR DESCRIPTION
## Summary and Scope
With the latest nightly rebuild of the spilo-14.2.1-p7 image, the pgqd package was updated from 3.3-5 to 3.5.1.
That change resulted in deprecation of some of the config values in the /home/postgres/pgq_ticker.ini file.
This fix overwrites the pgq_ticker.ini file in the postgres container due to change in pgqd:3.5-1.
This fix will allow for the image ([spilo-14.2.1-p7.yaml](https://github.com/Cray-HPE/container-images/actions/workflows/registry.opensource.zalan.do.acid.spilo-14.2.1-p7.yaml) to be rebuilt with all the latest packages such that the CSM 1.5 postgres clusters can then pick up the change.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMPET-6373](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-6373)
* Change will also be needed in NA
* Future work required by NA
* Documentation changes required in NA
* Merge with/before/after NA

## Testing

### Tested on:

* local docker build environment

### Test description:

Verified that the expected file is in place and that the `pgqd pgq_ticker.ini` does not fail reading the config
Old image:
```
root@608ab58fbca1:/home/postgres# dpkg -l | grep pgqd
ii  pgqd                                  3.5-1.pgdg18.04+1                   amd64        Queue maintenance daemon for PgQ

root@a2fa59a012c4:/home/postgres# more pgq_ticker.ini
[pgqd]
job_name = ticker
initial_database = postgres

# how often to run maintenance [seconds]
maint_delay = 600

# how often to check for activity [seconds]
loop_delay = 60

root@718f32cc0dea:/home/postgres# pgqd pgq_ticker.ini
2023-03-03 17:42:27.180 UTC [19] ERROR unknown parameter: pgqd/job_name
2023-03-03 17:42:27.180 UTC [19] ERROR invalid value "ticker" for parameter job_name in configuration (pgq_ticker.ini:2)
2023-03-03 17:42:27.180 UTC [19] FATAL @src/pgqd.c:88 in function load_config(): failed to read config
```
Updated image:
```
root@6271303d048f:/home/postgres# cat pgq_ticker.ini
[pgqd]
initial_database = postgres

# how often to do maintentance, in seconds.
maint_period = 600
# how often to run ticker, in seconds.
ticker_period = 60

logfile = ~/log/pgqd.log
pidfile = ~/pid/pgqd.pid

root@6271303d048f:/home/postgres# pgqd pgq_ticker.ini
2023-03-03 17:46:28.273 UTC [18] LOG Starting pgqd 3.5
2023-03-03 17:46:28.274 UTC [18] LOG auto-detecting dbs ...
2023-03-03 17:46:28.276 UTC [18] ERROR connection error: PQconnectStart
...
```

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

Low

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable
