### PR TITLE
CASMPET-6409: Fix more snyk failures causing cilium build failures

### DIFF
--- a/.github/workflows/docker.io.coredns.coredns.1.9.3.yaml
+++ b/.github/workflows/docker.io.coredns.coredns.1.9.3.yaml
@@ -57,4 +57,4 @@ jobs:
           cosign_key: ${{ secrets.COSIGN_KEY }}
           snyk_token: ${{ secrets.SNYK_TOKEN }}
           github_sha: $GITHUB_SHA
-          fail_on_snyk_errors: true
+          fail_on_snyk_errors: false

--- a/.github/workflows/quay.io.cilium.hubble-relay.v1.11.6.yaml
+++ b/.github/workflows/quay.io.cilium.hubble-relay.v1.11.6.yaml
@@ -55,4 +55,4 @@ jobs:
           cosign_key: ${{ secrets.COSIGN_KEY }}
           snyk_token: ${{ secrets.SNYK_TOKEN }}
           github_sha: $GITHUB_SHA
-          fail_on_snyk_errors: true
+          fail_on_snyk_errors: false

--- a/.github/workflows/quay.io.cilium.hubble-relay.v1.12.0.yaml
+++ b/.github/workflows/quay.io.cilium.hubble-relay.v1.12.0.yaml
@@ -55,4 +55,4 @@ jobs:
           cosign_key: ${{ secrets.COSIGN_KEY }}
           snyk_token: ${{ secrets.SNYK_TOKEN }}
           github_sha: $GITHUB_SHA
-          fail_on_snyk_errors: true
+          fail_on_snyk_errors: false

--- a/.github/workflows/quay.io.cilium.hubble-relay.v1.12.2.yaml
+++ b/.github/workflows/quay.io.cilium.hubble-relay.v1.12.2.yaml
@@ -55,4 +55,4 @@ jobs:
           cosign_key: ${{ secrets.COSIGN_KEY }}
           snyk_token: ${{ secrets.SNYK_TOKEN }}
           github_sha: $GITHUB_SHA
-          fail_on_snyk_errors: true
+          fail_on_snyk_errors: false

--- a/.github/workflows/quay.io.cilium.hubble-relay.v1.12.4.yaml
+++ b/.github/workflows/quay.io.cilium.hubble-relay.v1.12.4.yaml
@@ -57,4 +57,4 @@ jobs:
           cosign_key: ${{ secrets.COSIGN_KEY }}
           snyk_token: ${{ secrets.SNYK_TOKEN }}
           github_sha: $GITHUB_SHA
-          fail_on_snyk_errors: true
+          fail_on_snyk_errors: false

--- a/.github/workflows/quay.io.cilium.operator-generic.v1.11.6.yaml
+++ b/.github/workflows/quay.io.cilium.operator-generic.v1.11.6.yaml
@@ -55,4 +55,4 @@ jobs:
           cosign_key: ${{ secrets.COSIGN_KEY }}
           snyk_token: ${{ secrets.SNYK_TOKEN }}
           github_sha: $GITHUB_SHA
-          fail_on_snyk_errors: true
+          fail_on_snyk_errors: false

--- a/.github/workflows/quay.io.cilium.operator-generic.v1.12.0.yaml
+++ b/.github/workflows/quay.io.cilium.operator-generic.v1.12.0.yaml
@@ -55,4 +55,4 @@ jobs:
           cosign_key: ${{ secrets.COSIGN_KEY }}
           snyk_token: ${{ secrets.SNYK_TOKEN }}
           github_sha: $GITHUB_SHA
-          fail_on_snyk_errors: true
+          fail_on_snyk_errors: false

--- a/.github/workflows/quay.io.cilium.operator-generic.v1.12.2.yaml
+++ b/.github/workflows/quay.io.cilium.operator-generic.v1.12.2.yaml
@@ -55,4 +55,4 @@ jobs:
           cosign_key: ${{ secrets.COSIGN_KEY }}
           snyk_token: ${{ secrets.SNYK_TOKEN }}
           github_sha: $GITHUB_SHA
-          fail_on_snyk_errors: true
+          fail_on_snyk_errors: false

--- a/.github/workflows/quay.io.cilium.operator-generic.v1.12.3.yaml
+++ b/.github/workflows/quay.io.cilium.operator-generic.v1.12.3.yaml
@@ -57,4 +57,4 @@ jobs:
           cosign_key: ${{ secrets.COSIGN_KEY }}
           snyk_token: ${{ secrets.SNYK_TOKEN }}
           github_sha: $GITHUB_SHA
-          fail_on_snyk_errors: true
+          fail_on_snyk_errors: false


### PR DESCRIPTION
## Summary and Scope

Some more cilium image builds started to fail after new vulnerabilities were added to the snyk database.   These are upstream images so I set the fail_on_snyk_error to false as recommended to suppress the error. 

## Issues and Related PRs

* Resolves [CASMPET-6904](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-6904)

## Testing

Verified no failure in the branch build.


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

