### PR TITLE
CASMPET-6427 : Fix Cannot open logfile /home/postgres/log/pgqd.log

### DIFF
--- a/registry.opensource.zalan.do/acid/spilo-12/1.6-p3/Dockerfile
+++ b/registry.opensource.zalan.do/acid/spilo-12/1.6-p3/Dockerfile
@@ -34,7 +34,8 @@ RUN apt-get update && \
 
 # Overwrite the pgq_ticker.ini file in the postgres container due to change in pgqd:3.5-1
 # https://github.com/zalando/spilo/issues/838
-RUN mkdir /root/log /root/pid
+RUN mkdir /home/postgres/log /home/postgres/pid
+RUN chown -R 101:103 /home/postgres/log /home/postgres/pid
 COPY ./pgq_ticker.ini /home/postgres/pgq_ticker.ini
 
 # Capture psql version and packages to the build logs

--- a/registry.opensource.zalan.do/acid/spilo-14/2.1-p7/Dockerfile
+++ b/registry.opensource.zalan.do/acid/spilo-14/2.1-p7/Dockerfile
@@ -28,7 +28,8 @@ RUN apt-get -y update && apt-get upgrade -y && apt full-upgrade -y\
 
 # Overwrite the pgq_ticker.ini file in the postgres container due to change in pgqd:3.5-1
 # https://github.com/zalando/spilo/issues/838
-RUN mkdir /root/log /root/pid
+RUN mkdir /home/postgres/log /home/postgres/pid
+RUN chown -R 101:103 /home/postgres/log /home/postgres/pid
 COPY ./pgq_ticker.ini /home/postgres/pgq_ticker.ini
 
 # Capture psql version and packages to the build logs


### PR DESCRIPTION
## Summary and Scope

Recent image needs to adjust the log and pid directory and ownership to fix an issue where the log and pid dirs are not accessible by the postgres user.

The spilo-12 image is used by the postgres containers in CSM1.4
The spilo-14 image is used by the postgres containers in CSM 1.5

## Issues and Related PRs

* Resolves [CASMPET-6427](https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-6427)
* Change will also be needed in `<insert branch name here>`
* Future work required by [issue id](issue link)
* Documentation changes required in [issue id](issue link)
* Merge with/before/after `<insert PR URL here>`

## Testing

### Tested on:

* docker build & run on laptop
*  vshasta v2 (dorian)

### Test description:

Local build and test of the image
```
# ls -l | grep "log\|pid"
drwxr-xr-x 1 postgres postgres 4096 Mar 17 16:08 log
drwxr-xr-x 1 postgres postgres 4096 Mar 17 16:08 pid
```

Dorian - postgres logs show the issue is resolved after the directory and permssions are fixed
```
2023-03-17 16:17:09.327 UTC 1115 FATAL Cannot open logfile: '/home/postgres/log/pgqd.log': No such file or directory
2023-03-17 16:17:10.364 UTC 1120 FATAL Cannot open logfile: '/home/postgres/log/pgqd.log': No such file or directory
2023-03-17 16:17:11.401 UTC 1125 FATAL Cannot open logfile: '/home/postgres/log/pgqd.log': No such file or directory
2023-03-17 16:17:12.438 UTC 1130 FATAL Cannot open logfile: '/home/postgres/log/pgqd.log': No such file or directory
2023-03-17 16:17:13.477 UTC 1136 FATAL Cannot open logfile: '/home/postgres/log/pgqd.log': No such file or directory
2023-03-17 16:17:14.542 UTC [1143] LOG Starting pgqd 3.5     <------ fix was applied 
2023-03-17 16:17:14.543 UTC [1143] LOG auto-detecting dbs ...
2023-03-17 16:17:17,906 INFO: no action. I am (keycloak-postgres-2), the leader with the lock
2023-03-17 16:17:27,866 INFO: no action. I am (keycloak-postgres-2), the leader with the lock
2023-03-17 16:17:37,866 INFO: no action. I am (keycloak-postgres-2), the leader with the lock
```

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [ x Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

