### PR TITLE
CASMMON-312: Push thanos image to the artifactory (container_images)

### DIFF
--- a/.github/workflows/quay.io.thanos.v0.31.0.yaml
+++ b/.github/workflows/quay.io.thanos.v0.31.0.yaml
@@ -1,0 +1,60 @@
+#
+# MIT License
+#
+# (C) Copyright [2022] Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+name: quay.io/thanos:v0.31.0
+on:
+  push:
+    paths:
+      - .github/workflows/quay.io.thanos.v0.31.0.yaml
+      - quay.io/thanos/v0.31.0/**
+  workflow_dispatch:
+  schedule:
+    - cron: '1 8 * * *'
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      CONTEXT_PATH: quay.io/thanos/v0.31.0
+      DOCKER_REPO: artifactory.algol60.net/csm-docker/stable/quay.io/thanos
+      DOCKER_TAG: v0.31.0
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+      - name: build-sign-scan
+        uses: Cray-HPE/github-actions/build-sign-scan@main
+        with:
+          # Only push on main builds
+          docker_push: ${{ github.ref == 'refs/heads/main' }}
+          context_path: ${{ env.CONTEXT_PATH }}
+          docker_repo: ${{ env.DOCKER_REPO }}
+          docker_tag: ${{ env.DOCKER_TAG }}
+          artifactory_algol60_token: ${{ secrets.ARTIFACTORY_ALGOL60_TOKEN }}
+          cosign_gcp_workload_identity_provider: ${{ secrets.COSIGN_GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          cosign_gcp_service_account: ${{ secrets.COSIGN_GCP_SERVICE_ACCOUNT }}
+          cosign_key: ${{ secrets.COSIGN_KEY }}
+          snyk_token: ${{ secrets.SNYK_TOKEN }}
+          github_sha: $GITHUB_SHA
+          fail_on_snyk_errors: false  # upstream image

--- a/quay.io/thanos/v0.31.0/Dockerfile
+++ b/quay.io/thanos/v0.31.0/Dockerfile
@@ -1,0 +1,1 @@
+FROM quay.io/thanos/thanos:v0.31.0


### PR DESCRIPTION
## Summary and Scope

_Summarize what has changed. Explain why this PR is necessary. What is impacted? Is this a new feature, critical bug fix, etc?_

Push thanos image to the artifactory for thanos support for Prometheus scalability.

_Is this change backwards incompatible, backwards compatible, or a backwards compatible bugfix?_

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves -  https://jira-pro.its.hpecorp.net:8443/browse/CASMMON-312

### Tested on:

Gamora

ncn-m001:/mnt/developer/shreni # kubectl get pods -n sysmgmt-health
NAME                                                            READY   STATUS      RESTARTS   AGE
alertmanager-cray-sysmgmt-health-kube-p-alertmanager-0          2/2     Running     1          6m41s
cray-sysmgmt-health-grafana-56c6b46bcc-7r9vz                    3/3     Running     0          6m46s
cray-sysmgmt-health-grafterm-555dcffcd4-5ck5t                   1/1     Running     0          6m46s
cray-sysmgmt-health-grok-exporter-d68865c8-jt4nt                1/1     Running     0          6m45s
cray-sysmgmt-health-grok-exporter-d68865c8-s5wv5                1/1     Running     0          6m45s
cray-sysmgmt-health-grok-exporter-d68865c8-w7flc                1/1     Running     0          6m46s
cray-sysmgmt-health-kube-p-operator-8c887859f-sw9cd             1/1     Running     0          6m46s
cray-sysmgmt-health-kube-state-metrics-9ccffd45f-8ffbp          1/1     Running     0          6m46s
cray-sysmgmt-health-node-exporter-smartmon-4xrpk                1/1     Running     0          6m46s
cray-sysmgmt-health-node-exporter-smartmon-9rbcp                1/1     Running     0          6m44s
cray-sysmgmt-health-node-exporter-smartmon-drv9c                1/1     Running     0          6m44s
cray-sysmgmt-health-node-exporter-smartmon-fvx2d                1/1     Running     0          6m45s
cray-sysmgmt-health-node-exporter-smartmon-hdj5k                1/1     Running     0          6m45s
cray-sysmgmt-health-node-exporter-smartmon-mgq79                1/1     Running     0          6m44s
cray-sysmgmt-health-patch-nodeexporter-alerts-1-rf5cs           0/1     Completed   0          5m48s
cray-sysmgmt-health-patch-service-monitors-1-sh5hp              0/1     Completed   0          6m46s
cray-sysmgmt-health-prometheus-node-exporter-6b66b              1/1     Running     0          5m18s
cray-sysmgmt-health-prometheus-node-exporter-82fbk              1/1     Running     0          5m41s
cray-sysmgmt-health-prometheus-node-exporter-h49jl              1/1     Running     0          5m45s
cray-sysmgmt-health-prometheus-node-exporter-mlgdz              1/1     Running     0          5m1s
cray-sysmgmt-health-prometheus-node-exporter-rv5qf              1/1     Running     0          5m27s
cray-sysmgmt-health-prometheus-node-exporter-z8pmh              1/1     Running     0          5m23s
cray-sysmgmt-health-prometheus-snmp-exporter-7d96ff9ccd-br5vb   1/1     Running     0          6m46s
cray-sysmgmt-health-thanos-compactor-0                          1/1     Running     0          6m46s
cray-sysmgmt-health-thanos-store-0                              1/1     Running     1          6m46s
prometheus-cray-sysmgmt-health-kube-p-prom-0                    3/3     Running     0          6m41s
prometheus-cray-sysmgmt-health-kube-p-prom-1                    3/3     Running     0          6m40s
prometheus-cray-sysmgmt-health-kube-p-prom-shard-1-0            3/3     Running     0          6m41s
prometheus-cray-sysmgmt-health-kube-p-prom-shard-1-1            3/3     Running     0          6m41s
thanos-query-0                                                  1/1     Running     0          6m45s
thanos-ruler-kube-prometheus-stack-thanos-ruler-0               2/2     Running     0          6m42s
