### PR TITLE
Add newer version of metric-server for K8S 1.22 (CASMPET-6639)

### DIFF
--- a/.github/workflows/registry.k8s.io.metrics-server.metrics-server.v0.6.3.yaml
+++ b/.github/workflows/registry.k8s.io.metrics-server.metrics-server.v0.6.3.yaml
@@ -1,0 +1,60 @@
+#
+# MIT License
+#
+# (C) Copyright [2023] Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+name: registry.k8s.io/metrics-server/metrics-server:v0.6.3
+on:
+  push:
+    paths:
+      - .github/workflows/registry.k8s.io.metrics-server.metrics-server.v0.6.3.yaml
+      - registry.k8s.io/metrics-server/metrics-server/v0.6.3/**
+  workflow_dispatch:
+  schedule:
+    - cron: '7 10 * * *'
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      CONTEXT_PATH: registry.k8s.io/metrics-server/metrics-server/v0.6.3
+      DOCKER_REPO: artifactory.algol60.net/csm-docker/stable/registry.k8s.io/metrics-server/metrics-server
+      DOCKER_TAG: v0.6.3
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+      - name: build-sign-scan
+        uses: Cray-HPE/github-actions/build-sign-scan@main
+        with:
+          # Only push on main builds
+          docker_push: ${{ github.ref == 'refs/heads/main' }}
+          context_path: ${{ env.CONTEXT_PATH }}
+          docker_repo: ${{ env.DOCKER_REPO }}
+          docker_tag: ${{ env.DOCKER_TAG }}
+          artifactory_algol60_token: ${{ secrets.ARTIFACTORY_ALGOL60_TOKEN }}
+          cosign_gcp_workload_identity_provider: ${{ secrets.COSIGN_GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          cosign_gcp_service_account: ${{ secrets.COSIGN_GCP_SERVICE_ACCOUNT }}
+          cosign_key: ${{ secrets.COSIGN_KEY }}
+          snyk_token: ${{ secrets.SNYK_TOKEN }}
+          github_sha: $GITHUB_SHA
+          fail_on_snyk_errors: true

--- a/registry.k8s.io/metrics-server/metrics-server/v0.6.3/Dockerfile
+++ b/registry.k8s.io/metrics-server/metrics-server/v0.6.3/Dockerfile
@@ -1,0 +1,24 @@
+#
+# MIT License
+#
+# (C) Copyright [2023] Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+FROM registry.k8s.io/metrics-server/metrics-server:v0.6.3


### PR DESCRIPTION
### Summary and Scope

New metric-server image for K8S 1.22

### Issues and Related PRs

* https://jira-pro.it.hpe.com:8443/browse/CASMPET-6639

### Testing

Tested on ashton:

```
pit:~ # helm history -n kube-system cray-metrics-server
REVISION	UPDATED                 	STATUS    	CHART                    	APP VERSION	DESCRIPTION
1       	Sun Jun 25 14:37:38 2023	superseded	cray-metrics-server-0.4.1	v0.3.6     	Install complete
2       	Wed Jun 28 17:23:51 2023	deployed  	cray-metrics-server-0.5.0	v0.6.3     	Upgrade complete
```

```
pit:~/brad # kubectl logs -n kube-system metrics-server-86bff57b87-cw2j4
I0628 17:30:26.279095       1 serving.go:342] Generated self-signed cert (/tmp/apiserver.crt, /tmp/apiserver.key)
I0628 17:30:27.616407       1 requestheader_controller.go:169] Starting RequestHeaderAuthRequestController
I0628 17:30:27.616441       1 configmap_cafile_content.go:201] "Starting controller" name="client-ca::kube-system::extension-apiserver-authentication::client-ca-file"
I0628 17:30:27.616470       1 shared_informer.go:240] Waiting for caches to sync for client-ca::kube-system::extension-apiserver-authentication::client-ca-file
I0628 17:30:27.616469       1 configmap_cafile_content.go:201] "Starting controller" name="client-ca::kube-system::extension-apiserver-authentication::requestheader-client-ca-file"
I0628 17:30:27.616491       1 shared_informer.go:240] Waiting for caches to sync for client-ca::kube-system::extension-apiserver-authentication::requestheader-client-ca-file
I0628 17:30:27.616453       1 shared_informer.go:240] Waiting for caches to sync for RequestHeaderAuthRequestController
I0628 17:30:27.616682       1 secure_serving.go:267] Serving securely on [::]:4443
I0628 17:30:27.616734       1 tlsconfig.go:240] "Starting DynamicServingCertificateController"
W0628 17:30:27.616794       1 shared_informer.go:372] The sharedIndexInformer has started, run more than once is not allowed
I0628 17:30:27.616783       1 dynamic_serving_content.go:131] "Starting controller" name="serving-cert::/tmp/apiserver.crt::/tmp/apiserver.key"
I0628 17:30:27.717303       1 shared_informer.go:247] Caches are synced for RequestHeaderAuthRequestController
I0628 17:30:27.717329       1 shared_informer.go:247] Caches are synced for client-ca::kube-system::extension-apiserver-authentication::client-ca-file
I0628 17:30:27.717337       1 shared_informer.go:247] Caches are synced for client-ca::kube-system::extension-apiserver-authentication::requestheader-client-ca-file
```

Was a fresh Install tested? N
Was an Upgrade tested?      N - N/A
Was a Downgrade tested?     N - N/A
If schema changes were part of this change, how were those handled in your upgrade/downgrade testing? N/A

### Risks and Mitigations

Low

### Requires:

* Nothing
