### PR TITLE
New pet-util image for 1.6 -- new boto3/kubectl/awscli

### DIFF
--- a/.github/workflows/docker.io.demisto.boto3py3.pet-utils-csm-1.6.yaml
+++ b/.github/workflows/docker.io.demisto.boto3py3.pet-utils-csm-1.6.yaml
@@ -1,0 +1,58 @@
+#
+# MIT License
+#
+# (C) Copyright [2023] Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+name: docker.io/demisto/boto3py3:pet-utils-csm-1.6
+on:
+  push:
+    paths:
+      - .github/workflows/docker.io.demisto.boto3py3.pet-utils-csm-1.6.yaml
+      - docker.io/demisto/boto3py3/pet-utils-csm-1.6/**
+  workflow_dispatch:
+  schedule:
+    - cron: '19 1 * * *'
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      CONTEXT_PATH: docker.io/demisto/boto3py3/pet-utils-csm-1.6
+      DOCKER_REPO: artifactory.algol60.net/csm-docker/${{ github.ref == 'refs/heads/main' && 'stable' || 'unstable' }}/docker.io/demisto/boto3py3
+      DOCKER_TAG: pet-utils-csm-1.6
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+      - name: build-sign-scan
+        uses: Cray-HPE/github-actions/build-sign-scan@main
+        with:
+          context_path: ${{ env.CONTEXT_PATH }}
+          docker_repo: ${{ env.DOCKER_REPO }}
+          docker_tag: ${{ env.DOCKER_TAG }}
+          artifactory_algol60_token: ${{ secrets.ARTIFACTORY_ALGOL60_TOKEN }}
+          cosign_gcp_workload_identity_provider: ${{ secrets.COSIGN_GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          cosign_gcp_service_account: ${{ secrets.COSIGN_GCP_SERVICE_ACCOUNT }}
+          cosign_key: ${{ secrets.COSIGN_KEY }}
+          snyk_token: ${{ secrets.SNYK_TOKEN }}
+          github_sha: $GITHUB_SHA
+          fail_on_snyk_errors: false

--- a/docker.io/demisto/boto3py3/pet-utils-csm-1.6/Dockerfile
+++ b/docker.io/demisto/boto3py3/pet-utils-csm-1.6/Dockerfile
@@ -1,0 +1,40 @@
+#
+# MIT License
+#
+# (C) Copyright [2023] Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+FROM docker.io/demisto/boto3py3:1.0.0.79403
+
+#
+# Constructing this pet-util image, we add kubectl first:
+#
+RUN wget -q https://storage.googleapis.com/kubernetes-release/release/v1.23.17/bin/linux/amd64/kubectl -O /usr/local/bin/kubectl && chmod +x /usr/local/bin/kubectl
+
+RUN apk update && \
+    apk add --upgrade apk-tools &&  \
+    apk -U upgrade && \
+    rm -rf /var/cache/apk/*
+
+#
+# Finally we bring in aws cli:
+#
+RUN pip install --upgrade pip && \
+    pip install --upgrade awscli


### PR DESCRIPTION
### Summary and Scope

New util image with boto3, kubectl and awscli

### Issues and Related PRs

  * CASMPET-6758: update bitnami-etcd container with upstream merge

### Testing

beau:
```
pit:~/brad # kubectl get pod/cray-etcd-test-etcd-post-install-nqpd4 -n services -o yaml | grep demis
    image: artifactory.algol60.net/csm-docker/stable/docker.io/demisto/boto3py3:pet-utils-csm-1.6
```

```
pit:~/brad # kubectl logs pod/cray-etcd-test-etcd-post-install-nqpd4 -n services
Patching snapshotter cronjob to remove labels to allow scheduling alongside etcd pods..
cronjob.batch/cray-etcd-test-bitnami-etcd-snapshotter patched
cronjob.batch/cray-etcd-test-bitnami-etcd-snapshotter patched
Grabbing keys and S3 endpoint from etcd-backup-s3-credentials...
Download snapshot cray-etcd-test_etcd_migration.snapshot-1.db from http://rgw-vip.nmn...
cray-etcd-test_etcd_migration.snapshot-1.db not found, proceeding without data migration...
Waiting for 3 pods to be ready...
Waiting for 2 pods to be ready...
Waiting for 1 pods to be ready...
statefulset rolling update complete 3 pods at revision cray-etcd-test-bitnami-etcd-864c9f4d98...
Taking initial snapshot of cluster...
Terminated
etcd 22:15:36.50 WARN  ==> etcd endpoint cray-etcd-test-bitnami-etcd-0.cray-etcd-test-bitnami-etcd-headless.services.svc.cluster.local:2379 not healthy. Trying a different endpoint
cray-etcd-test-bitnami-etcd-1.cray-etcd-test-bitnami-etcd-headless.services.svc.cluster.local:2379 is healthy: successfully committed proposal: took = 21.195615ms
etcd 22:15:36.57 INFO  ==> Snapshotting the keyspace
{"level":"info","ts":"2023-10-23T22:15:36.610206Z","caller":"snapshot/v3_snapshot.go:65","msg":"created temporary db file","path":"/snapshots/cray-etcd-test-bitnami-etcd/db-2023-10-23_22-15.part"}
{"level":"info","ts":"2023-10-23T22:15:36.611594Z","logger":"client","caller":"v3@v3.5.9/maintenance.go:212","msg":"opened snapshot stream; downloading"}
{"level":"info","ts":"2023-10-23T22:15:36.611672Z","caller":"snapshot/v3_snapshot.go:73","msg":"fetching snapshot","endpoint":"cray-etcd-test-bitnami-etcd-1.cray-etcd-test-bitnami-etcd-headless.services.svc.cluster.local:2379"}
{"level":"info","ts":"2023-10-23T22:15:36.64041Z","logger":"client","caller":"v3@v3.5.9/maintenance.go:220","msg":"completed snapshot read; closing"}
{"level":"info","ts":"2023-10-23T22:15:36.651489Z","caller":"snapshot/v3_snapshot.go:88","msg":"fetched snapshot","endpoint":"cray-etcd-test-bitnami-etcd-1.cray-etcd-test-bitnami-etcd-headless.services.svc.cluster.local:2379","size":"20 kB","took":"now"}
{"level":"info","ts":"2023-10-23T22:15:36.652478Z","caller":"snapshot/v3_snapshot.go:97","msg":"saved","path":"/snapshots/cray-etcd-test-bitnami-etcd/db-2023-10-23_22-15"}
Snapshot saved at /snapshots/cray-etcd-test-bitnami-etcd/db-2023-10-23_22-15
Uploading snapshot db-2023-10-23_22-15 to http://rgw-vip.nmn...
Editing etcd statefulset to existing (instead of new cluster)...
statefulset.apps/cray-etcd-test-bitnami-etcd env updated
```

Was a fresh Install tested? N
Was an Upgrade tested?      N - N/A
Was a Downgrade tested?     N - N/A
If schema changes were part of this change, how were those handled in your upgrade/downgrade testing? N/A

### Risks and Mitigations

Low

### Requires:

* Nothing

