### PR TITLE
CASMPET-6969 CASMPET-7009 CASMPET-7010 Fix spilo container builds

### DIFF
--- a/registry.opensource.zalan.do/acid/logical-backup/v1.8.2/Dockerfile
+++ b/registry.opensource.zalan.do/acid/logical-backup/v1.8.2/Dockerfile
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright [2022] Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -23,5 +23,6 @@
 #
 FROM registry.opensource.zalan.do/acid/logical-backup:v1.8.2
 
-RUN apt-get -y update && apt-get upgrade -y && apt full-upgrade -y\
+RUN sed -i -e 's/apt\.postgresql\.org/apt-archive.postgresql.org/' /etc/apt/sources.list.d/pgdg.list \
+    && apt-get -y update && apt-get upgrade -y && apt full-upgrade -y\
     && rm -rf /var/lib/apt/lists/

--- a/registry.opensource.zalan.do/acid/spilo-12/1.6-p3/Dockerfile
+++ b/registry.opensource.zalan.do/acid/spilo-12/1.6-p3/Dockerfile
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright [2022] Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -23,10 +23,11 @@
 #
 FROM registry.opensource.zalan.do/acid/spilo-12:1.6-p3
 ENV DEBIAN_FRONTEND noninteractive
-RUN apt-get update && \
-    # pbbouncer auto upgrade can not be run in noninteractive mode
+RUN sed -i -e 's/apt\.postgresql\.org/apt-archive.postgresql.org/' /etc/apt/sources.list.d/pgdg.list \
+    && apt-get update -y && \
+    # pgbouncer auto upgrade can not be run in noninteractive mode
     # force upgrade/reinstall
-    apt-get -o Dpkg::Options::="--force-confnew" install pgbouncer && \ 
+    apt-get -o Dpkg::Options::="--force-confnew" install pgbouncer && \
     apt-get upgrade -y && rm -rf /var/lib/apt/lists/* && \
     sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen \
     && dpkg-reconfigure --frontend=noninteractive locales \

--- a/registry.opensource.zalan.do/acid/spilo-14/2.1-p7/Dockerfile
+++ b/registry.opensource.zalan.do/acid/spilo-14/2.1-p7/Dockerfile
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright [2022-2023] Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -22,9 +22,13 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 FROM registry.opensource.zalan.do/acid/spilo-14:2.1-p7
-
-RUN apt-get -y update && apt-get upgrade -y && apt full-upgrade -y\
-    && rm -rf /var/lib/apt/lists/
+ENV DEBIAN_FRONTEND noninteractive
+RUN sed -i -e 's/apt\.postgresql\.org/apt-archive.postgresql.org/' /etc/apt/sources.list.d/pgdg.list \
+    && apt-get update -y && \
+    # pgbouncer auto upgrade can not be run in noninteractive mode
+    # force upgrade/reinstall
+    apt-get -o Dpkg::Options::="--force-confnew" install pgbouncer && \
+    apt-get upgrade -y && rm -rf /var/lib/apt/lists/*
 
 # Overwrite the pgq_ticker.ini file in the postgres container due to change in pgqd:3.5-1
 # https://github.com/zalando/spilo/issues/838


### PR DESCRIPTION
## Summary and Scope

Container rebuilds for `spilo` were failing for quite a while, because packages for older OS (Ubuntu 18.04 Bionic) were moved from https://apt.postgresql.org to http://apt-archive.postgresql.org. This change fixes APT configuration to use new update site. Also re-applies the fix for pgbouncer used in `spilo-12` to `spilo-14`.

## Issues and Related PRs

* Resolves [CASMPET-6989](https://jira-pro.it.hpe.com:8443/browse/CASMPET-6989)
* Resolves [CASMPET-7009](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7009)
* Resolves [CASMPET-7010](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7010)

## Testing
### Tested on:

  * Github workflows

### Test description:

Image build is happy now.

## Risks and Mitigations

None known. We will use auto-upgraded images only in unreleased versions of CSM during testing. Once CSM is declared as fully tested, we freeze image digests and stop consuming auo-rebuilt images.
