### PR TITLE
CASMPET-6936 Adding images for strimzi kafka 0.41.0

### DIFF
--- a/.github/workflows/quay.io.strimzi.kafka-bridge.0.28.0.yaml
+++ b/.github/workflows/quay.io.strimzi.kafka-bridge.0.28.0.yaml
@@ -1,0 +1,54 @@
+#
+# MIT License
+#
+# (C) Copyright 2022, 2024 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+name: quay.io/strimzi/kafka-bridge:0.28.0
+on:
+  push:
+    paths:
+      - .github/workflows/quay.io.strimzi.kafka-bridge.0.28.0.yaml
+      - quay.io/strimzi/kafka-bridge/0.28.0/**
+  workflow_dispatch:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      CONTEXT_PATH: quay.io/strimzi/kafka-bridge/0.28.0
+      DOCKER_REPO: artifactory.algol60.net/csm-docker/${{ github.ref == 'refs/heads/main' && 'stable' || 'unstable' }}/quay.io/strimzi/kafka-bridge
+      DOCKER_TAG: 0.28.0
+    steps:
+      - name: build-sign-scan
+        uses: Cray-HPE/github-actions/build-sign-scan@build-sign-scan/v2
+        with:
+          context_path: ${{ env.CONTEXT_PATH }}
+          docker_repo: ${{ env.DOCKER_REPO }}
+          docker_tag: ${{ env.DOCKER_TAG }}
+          docker_username: ${{ secrets.ARTIFACTORY_ALGOL60_USERNAME }}
+          docker_password: ${{ secrets.ARTIFACTORY_ALGOL60_TOKEN }}
+          sign: ${{ github.ref == 'refs/heads/main' }}
+          cosign_gcp_workload_identity_provider: ${{ secrets.COSIGN_GCP_WORKLOAD_IDENTITY_PROVIDER_RSA }}
+          cosign_gcp_service_account: ${{ secrets.COSIGN_GCP_SERVICE_ACCOUNT_RSA }}
+          cosign_key: ${{ secrets.COSIGN_KEY_RSA }}
+          snyk_token: ${{ secrets.SNYK_TOKEN }}

--- a/.github/workflows/quay.io.strimzi.kafka-bridge.0.28.0.yaml
+++ b/.github/workflows/quay.io.strimzi.kafka-bridge.0.28.0.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022, 2024 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),

--- a/.github/workflows/quay.io.strimzi.kafka.0.41.0-noJSM-chainsaw-kafka-3.6.0.yaml
+++ b/.github/workflows/quay.io.strimzi.kafka.0.41.0-noJSM-chainsaw-kafka-3.6.0.yaml
@@ -1,0 +1,54 @@
+#
+# MIT License
+#
+# (C) Copyright 2022, 2024 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+name: quay.io/strimzi/kafka:0.41.0-noJSM-chainsaw-kafka-3.6.0
+on:
+  push:
+    paths:
+      - .github/workflows/quay.io.strimzi.kafka.0.41.0-noJSM-chainsaw-kafka-3.6.0.yaml
+      - quay.io/strimzi/kafka/0.41.0-noJSM-chainsaw-kafka-3.6.0/**
+  workflow_dispatch:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      CONTEXT_PATH: quay.io/strimzi/kafka/0.41.0-noJSM-chainsaw-kafka-3.6.0
+      DOCKER_REPO: artifactory.algol60.net/csm-docker/${{ github.ref == 'refs/heads/main' && 'stable' || 'unstable' }}/quay.io/strimzi/kafka
+      DOCKER_TAG: 0.41.0-noJSM-chainsaw-kafka-3.6.0
+    steps:
+      - name: build-sign-scan
+        uses: Cray-HPE/github-actions/build-sign-scan@build-sign-scan/v2
+        with:
+          context_path: ${{ env.CONTEXT_PATH }}
+          docker_repo: ${{ env.DOCKER_REPO }}
+          docker_tag: ${{ env.DOCKER_TAG }}
+          docker_username: ${{ secrets.ARTIFACTORY_ALGOL60_USERNAME }}
+          docker_password: ${{ secrets.ARTIFACTORY_ALGOL60_TOKEN }}
+          sign: ${{ github.ref == 'refs/heads/main' }}
+          cosign_gcp_workload_identity_provider: ${{ secrets.COSIGN_GCP_WORKLOAD_IDENTITY_PROVIDER_RSA }}
+          cosign_gcp_service_account: ${{ secrets.COSIGN_GCP_SERVICE_ACCOUNT_RSA }}
+          cosign_key: ${{ secrets.COSIGN_KEY_RSA }}
+          snyk_token: ${{ secrets.SNYK_TOKEN }}

--- a/.github/workflows/quay.io.strimzi.kafka.0.41.0-noJSM-chainsaw-kafka-3.6.0.yaml
+++ b/.github/workflows/quay.io.strimzi.kafka.0.41.0-noJSM-chainsaw-kafka-3.6.0.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022, 2024 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),

--- a/.github/workflows/quay.io.strimzi.kafka.0.41.0-noJSM-chainsaw-kafka-3.6.1.yaml
+++ b/.github/workflows/quay.io.strimzi.kafka.0.41.0-noJSM-chainsaw-kafka-3.6.1.yaml
@@ -1,0 +1,54 @@
+#
+# MIT License
+#
+# (C) Copyright 2022, 2024 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+name: quay.io/strimzi/kafka:0.41.0-noJSM-chainsaw-kafka-3.6.1
+on:
+  push:
+    paths:
+      - .github/workflows/quay.io.strimzi.kafka.0.41.0-noJSM-chainsaw-kafka-3.6.1.yaml
+      - quay.io/strimzi/kafka/0.41.0-noJSM-chainsaw-kafka-3.6.1/**
+  workflow_dispatch:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      CONTEXT_PATH: quay.io/strimzi/kafka/0.41.0-noJSM-chainsaw-kafka-3.6.1
+      DOCKER_REPO: artifactory.algol60.net/csm-docker/${{ github.ref == 'refs/heads/main' && 'stable' || 'unstable' }}/quay.io/strimzi/kafka
+      DOCKER_TAG: 0.41.0-noJSM-chainsaw-kafka-3.6.1
+    steps:
+      - name: build-sign-scan
+        uses: Cray-HPE/github-actions/build-sign-scan@build-sign-scan/v2
+        with:
+          context_path: ${{ env.CONTEXT_PATH }}
+          docker_repo: ${{ env.DOCKER_REPO }}
+          docker_tag: ${{ env.DOCKER_TAG }}
+          docker_username: ${{ secrets.ARTIFACTORY_ALGOL60_USERNAME }}
+          docker_password: ${{ secrets.ARTIFACTORY_ALGOL60_TOKEN }}
+          sign: ${{ github.ref == 'refs/heads/main' }}
+          cosign_gcp_workload_identity_provider: ${{ secrets.COSIGN_GCP_WORKLOAD_IDENTITY_PROVIDER_RSA }}
+          cosign_gcp_service_account: ${{ secrets.COSIGN_GCP_SERVICE_ACCOUNT_RSA }}
+          cosign_key: ${{ secrets.COSIGN_KEY_RSA }}
+          snyk_token: ${{ secrets.SNYK_TOKEN }}

--- a/.github/workflows/quay.io.strimzi.kafka.0.41.0-noJSM-chainsaw-kafka-3.6.1.yaml
+++ b/.github/workflows/quay.io.strimzi.kafka.0.41.0-noJSM-chainsaw-kafka-3.6.1.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022, 2024 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),

--- a/.github/workflows/quay.io.strimzi.kafka.0.41.0-noJSM-chainsaw-kafka-3.6.2.yaml
+++ b/.github/workflows/quay.io.strimzi.kafka.0.41.0-noJSM-chainsaw-kafka-3.6.2.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022, 2024 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),

--- a/.github/workflows/quay.io.strimzi.kafka.0.41.0-noJSM-chainsaw-kafka-3.6.2.yaml
+++ b/.github/workflows/quay.io.strimzi.kafka.0.41.0-noJSM-chainsaw-kafka-3.6.2.yaml
@@ -1,0 +1,54 @@
+#
+# MIT License
+#
+# (C) Copyright 2022, 2024 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+name: quay.io/strimzi/kafka:0.41.0-noJSM-chainsaw-kafka-3.6.2
+on:
+  push:
+    paths:
+      - .github/workflows/quay.io.strimzi.kafka.0.41.0-noJSM-chainsaw-kafka-3.6.2.yaml
+      - quay.io/strimzi/kafka/0.41.0-noJSM-chainsaw-kafka-3.6.2/**
+  workflow_dispatch:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      CONTEXT_PATH: quay.io/strimzi/kafka/0.41.0-noJSM-chainsaw-kafka-3.6.2
+      DOCKER_REPO: artifactory.algol60.net/csm-docker/${{ github.ref == 'refs/heads/main' && 'stable' || 'unstable' }}/quay.io/strimzi/kafka
+      DOCKER_TAG: 0.41.0-noJSM-chainsaw-kafka-3.6.2
+    steps:
+      - name: build-sign-scan
+        uses: Cray-HPE/github-actions/build-sign-scan@build-sign-scan/v2
+        with:
+          context_path: ${{ env.CONTEXT_PATH }}
+          docker_repo: ${{ env.DOCKER_REPO }}
+          docker_tag: ${{ env.DOCKER_TAG }}
+          docker_username: ${{ secrets.ARTIFACTORY_ALGOL60_USERNAME }}
+          docker_password: ${{ secrets.ARTIFACTORY_ALGOL60_TOKEN }}
+          sign: ${{ github.ref == 'refs/heads/main' }}
+          cosign_gcp_workload_identity_provider: ${{ secrets.COSIGN_GCP_WORKLOAD_IDENTITY_PROVIDER_RSA }}
+          cosign_gcp_service_account: ${{ secrets.COSIGN_GCP_SERVICE_ACCOUNT_RSA }}
+          cosign_key: ${{ secrets.COSIGN_KEY_RSA }}
+          snyk_token: ${{ secrets.SNYK_TOKEN }}

--- a/.github/workflows/quay.io.strimzi.kafka.0.41.0-noJSM-chainsaw-kafka-3.7.0.yaml
+++ b/.github/workflows/quay.io.strimzi.kafka.0.41.0-noJSM-chainsaw-kafka-3.7.0.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022, 2024 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),

--- a/.github/workflows/quay.io.strimzi.kafka.0.41.0-noJSM-chainsaw-kafka-3.7.0.yaml
+++ b/.github/workflows/quay.io.strimzi.kafka.0.41.0-noJSM-chainsaw-kafka-3.7.0.yaml
@@ -1,0 +1,54 @@
+#
+# MIT License
+#
+# (C) Copyright 2022, 2024 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+name: quay.io/strimzi/kafka:0.41.0-noJSM-chainsaw-kafka-3.7.0
+on:
+  push:
+    paths:
+      - .github/workflows/quay.io.strimzi.kafka.0.41.0-noJSM-chainsaw-kafka-3.7.0.yaml
+      - quay.io/strimzi/kafka/0.41.0-noJSM-chainsaw-kafka-3.7.0/**
+  workflow_dispatch:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      CONTEXT_PATH: quay.io/strimzi/kafka/0.41.0-noJSM-chainsaw-kafka-3.7.0
+      DOCKER_REPO: artifactory.algol60.net/csm-docker/${{ github.ref == 'refs/heads/main' && 'stable' || 'unstable' }}/quay.io/strimzi/kafka
+      DOCKER_TAG: 0.41.0-noJSM-chainsaw-kafka-3.7.0
+    steps:
+      - name: build-sign-scan
+        uses: Cray-HPE/github-actions/build-sign-scan@build-sign-scan/v2
+        with:
+          context_path: ${{ env.CONTEXT_PATH }}
+          docker_repo: ${{ env.DOCKER_REPO }}
+          docker_tag: ${{ env.DOCKER_TAG }}
+          docker_username: ${{ secrets.ARTIFACTORY_ALGOL60_USERNAME }}
+          docker_password: ${{ secrets.ARTIFACTORY_ALGOL60_TOKEN }}
+          sign: ${{ github.ref == 'refs/heads/main' }}
+          cosign_gcp_workload_identity_provider: ${{ secrets.COSIGN_GCP_WORKLOAD_IDENTITY_PROVIDER_RSA }}
+          cosign_gcp_service_account: ${{ secrets.COSIGN_GCP_SERVICE_ACCOUNT_RSA }}
+          cosign_key: ${{ secrets.COSIGN_KEY_RSA }}
+          snyk_token: ${{ secrets.SNYK_TOKEN }}

--- a/.github/workflows/quay.io.strimzi.operator.0.41.0.yaml
+++ b/.github/workflows/quay.io.strimzi.operator.0.41.0.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022, 2024 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),

--- a/.github/workflows/quay.io.strimzi.operator.0.41.0.yaml
+++ b/.github/workflows/quay.io.strimzi.operator.0.41.0.yaml
@@ -1,0 +1,54 @@
+#
+# MIT License
+#
+# (C) Copyright 2022, 2024 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+name: quay.io/strimzi/operator:0.41.0
+on:
+  push:
+    paths:
+      - .github/workflows/quay.io.strimzi.operator.0.41.0.yaml
+      - quay.io/strimzi/operator/0.41.0/**
+  workflow_dispatch:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      CONTEXT_PATH: quay.io/strimzi/operator/0.41.0
+      DOCKER_REPO: artifactory.algol60.net/csm-docker/${{ github.ref == 'refs/heads/main' && 'stable' || 'unstable' }}/quay.io/strimzi/operator
+      DOCKER_TAG: 0.41.0
+    steps:
+      - name: build-sign-scan
+        uses: Cray-HPE/github-actions/build-sign-scan@build-sign-scan/v2
+        with:
+          context_path: ${{ env.CONTEXT_PATH }}
+          docker_repo: ${{ env.DOCKER_REPO }}
+          docker_tag: ${{ env.DOCKER_TAG }}
+          docker_username: ${{ secrets.ARTIFACTORY_ALGOL60_USERNAME }}
+          docker_password: ${{ secrets.ARTIFACTORY_ALGOL60_TOKEN }}
+          sign: ${{ github.ref == 'refs/heads/main' }}
+          cosign_gcp_workload_identity_provider: ${{ secrets.COSIGN_GCP_WORKLOAD_IDENTITY_PROVIDER_RSA }}
+          cosign_gcp_service_account: ${{ secrets.COSIGN_GCP_SERVICE_ACCOUNT_RSA }}
+          cosign_key: ${{ secrets.COSIGN_KEY_RSA }}
+          snyk_token: ${{ secrets.SNYK_TOKEN }}

--- a/images.mk
+++ b/images.mk
@@ -336,6 +336,12 @@ QUAYIMAGES:=quay.io/strimzi/operator:0.15.0-noJndiLookupClass
 QUAYIMAGES:=quay.io/strimzi/operator:0.15.0
 QUAYIMAGES:=quay.io/strimzi/operator:0.27.0
 QUAYIMAGES:=quay.io/strimzi/operator:0.27.1
+QUAYIMAGES:=quay.io/strimzi/kafka:0.41.0-noJSM-chainsaw-kafka-3.6.0
+QUAYIMAGES:=quay.io/strimzi/kafka:0.41.0-noJSM-chainsaw-kafka-3.6.1
+QUAYIMAGES:=quay.io/strimzi/kafka:0.41.0-noJSM-chainsaw-kafka-3.6.2
+QUAYIMAGES:=quay.io/strimzi/kafka:0.41.0-noJSM-chainsaw-kafka-3.7.0
+QUAYIMAGES:=quay.io/strimzi/operator:0.41.0
+QUAYIMAGES:=quay.io/strimzi/kafka-bridge:0.28.0
 
 # bitnami images
 BITNAMIIMAGES:=registry.opensource.zalan.do/acid/logical-backup:master-58

--- a/quay.io/strimzi/kafka-bridge/0.28.0/Dockerfile
+++ b/quay.io/strimzi/kafka-bridge/0.28.0/Dockerfile
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright [2022] Hewlett Packard Enterprise Development LP
+# (C) Copyright [2024] Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),

--- a/quay.io/strimzi/kafka-bridge/0.28.0/Dockerfile
+++ b/quay.io/strimzi/kafka-bridge/0.28.0/Dockerfile
@@ -1,0 +1,27 @@
+#
+# MIT License
+#
+# (C) Copyright [2022] Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+FROM quay.io/strimzi/kafka-bridge:0.28.0
+USER root
+RUN microdnf -y update && microdnf clean all
+USER 1001

--- a/quay.io/strimzi/kafka/0.41.0-noJSM-chainsaw-kafka-3.6.0/Dockerfile
+++ b/quay.io/strimzi/kafka/0.41.0-noJSM-chainsaw-kafka-3.6.0/Dockerfile
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright [2022] Hewlett Packard Enterprise Development LP
+# (C) Copyright [2024] Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),

--- a/quay.io/strimzi/kafka/0.41.0-noJSM-chainsaw-kafka-3.6.0/Dockerfile
+++ b/quay.io/strimzi/kafka/0.41.0-noJSM-chainsaw-kafka-3.6.0/Dockerfile
@@ -1,0 +1,40 @@
+#
+# MIT License
+#
+# (C) Copyright [2022] Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+FROM quay.io/strimzi/kafka:0.41.0-kafka-3.6.0
+USER root
+RUN microdnf -y update && microdnf -y install zip && microdnf clean all
+
+# Mitigation for CVE-2021-4104
+#RUN zip -q -d /opt/kafka/libs/log4j-1.2.17.jar org/apache/log4j/net/JMSAppender.class
+
+# Mitigation for CVE-2022-23305
+#RUN zip -q -d /opt/kafka/libs/log4j-1.2.17.jar org/apache/log4j/jdbc/JDBCAppender.class
+
+# Mitigation for CVE-2022-23307
+#RUN zip -q -d /opt/kafka/libs/log4j-1.2.17.jar org/apache/log4j/chainsaw\*
+
+# Mitigation for CVE-2022-23302
+#RUN zip -q -d /opt/kafka/libs/log4j-1.2.17.jar org/apache/log4j/net/JMSSink.class
+
+USER 1001

--- a/quay.io/strimzi/kafka/0.41.0-noJSM-chainsaw-kafka-3.6.1/Dockerfile
+++ b/quay.io/strimzi/kafka/0.41.0-noJSM-chainsaw-kafka-3.6.1/Dockerfile
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright [2022] Hewlett Packard Enterprise Development LP
+# (C) Copyright [2024] Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),

--- a/quay.io/strimzi/kafka/0.41.0-noJSM-chainsaw-kafka-3.6.1/Dockerfile
+++ b/quay.io/strimzi/kafka/0.41.0-noJSM-chainsaw-kafka-3.6.1/Dockerfile
@@ -1,0 +1,40 @@
+#
+# MIT License
+#
+# (C) Copyright [2022] Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+FROM quay.io/strimzi/kafka:0.41.0-kafka-3.6.1
+USER root
+RUN microdnf -y update && microdnf -y install zip && microdnf clean all
+
+# Mitigation for CVE-2021-4104
+#RUN zip -q -d /opt/kafka/libs/log4j-1.2.17.jar org/apache/log4j/net/JMSAppender.class
+
+# Mitigation for CVE-2022-23305
+#RUN zip -q -d /opt/kafka/libs/log4j-1.2.17.jar org/apache/log4j/jdbc/JDBCAppender.class
+
+# Mitigation for CVE-2022-23307
+#RUN zip -q -d /opt/kafka/libs/log4j-1.2.17.jar org/apache/log4j/chainsaw\*
+
+# Mitigation for CVE-2022-23302
+#RUN zip -q -d /opt/kafka/libs/log4j-1.2.17.jar org/apache/log4j/net/JMSSink.class
+
+USER 1001

--- a/quay.io/strimzi/kafka/0.41.0-noJSM-chainsaw-kafka-3.6.2/Dockerfile
+++ b/quay.io/strimzi/kafka/0.41.0-noJSM-chainsaw-kafka-3.6.2/Dockerfile
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright [2022] Hewlett Packard Enterprise Development LP
+# (C) Copyright [2024] Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),

--- a/quay.io/strimzi/kafka/0.41.0-noJSM-chainsaw-kafka-3.6.2/Dockerfile
+++ b/quay.io/strimzi/kafka/0.41.0-noJSM-chainsaw-kafka-3.6.2/Dockerfile
@@ -1,0 +1,40 @@
+#
+# MIT License
+#
+# (C) Copyright [2022] Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+FROM quay.io/strimzi/kafka:0.41.0-kafka-3.6.2
+USER root
+RUN microdnf -y update && microdnf -y install zip && microdnf clean all
+
+# Mitigation for CVE-2021-4104
+#RUN zip -q -d /opt/kafka/libs/log4j-1.2.17.jar org/apache/log4j/net/JMSAppender.class
+
+# Mitigation for CVE-2022-23305
+#RUN zip -q -d /opt/kafka/libs/log4j-1.2.17.jar org/apache/log4j/jdbc/JDBCAppender.class
+
+# Mitigation for CVE-2022-23307
+#RUN zip -q -d /opt/kafka/libs/log4j-1.2.17.jar org/apache/log4j/chainsaw\*
+
+# Mitigation for CVE-2022-23302
+#RUN zip -q -d /opt/kafka/libs/log4j-1.2.17.jar org/apache/log4j/net/JMSSink.class
+
+USER 1001

--- a/quay.io/strimzi/kafka/0.41.0-noJSM-chainsaw-kafka-3.7.0/Dockerfile
+++ b/quay.io/strimzi/kafka/0.41.0-noJSM-chainsaw-kafka-3.7.0/Dockerfile
@@ -1,0 +1,40 @@
+#
+# MIT License
+#
+# (C) Copyright [2022] Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+FROM quay.io/strimzi/kafka:0.41.0-kafka-3.7.0
+USER root
+RUN microdnf -y update && microdnf -y install zip && microdnf clean all
+
+# Mitigation for CVE-2021-4104
+#RUN zip -q -d /opt/kafka/libs/log4j-1.2.17.jar org/apache/log4j/net/JMSAppender.class
+
+# Mitigation for CVE-2022-23305
+#RUN zip -q -d /opt/kafka/libs/log4j-1.2.17.jar org/apache/log4j/jdbc/JDBCAppender.class
+
+# Mitigation for CVE-2022-23307
+#RUN zip -q -d /opt/kafka/libs/log4j-1.2.17.jar org/apache/log4j/chainsaw\*
+
+# Mitigation for CVE-2022-23302
+#RUN zip -q -d /opt/kafka/libs/log4j-1.2.17.jar org/apache/log4j/net/JMSSink.class
+
+USER 1001

--- a/quay.io/strimzi/kafka/0.41.0-noJSM-chainsaw-kafka-3.7.0/Dockerfile
+++ b/quay.io/strimzi/kafka/0.41.0-noJSM-chainsaw-kafka-3.7.0/Dockerfile
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright [2022] Hewlett Packard Enterprise Development LP
+# (C) Copyright [2024] Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),

--- a/quay.io/strimzi/operator/0.41.0/Dockerfile
+++ b/quay.io/strimzi/operator/0.41.0/Dockerfile
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright [2022] Hewlett Packard Enterprise Development LP
+# (C) Copyright [2024] Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),

--- a/quay.io/strimzi/operator/0.41.0/Dockerfile
+++ b/quay.io/strimzi/operator/0.41.0/Dockerfile
@@ -1,0 +1,27 @@
+#
+# MIT License
+#
+# (C) Copyright [2022] Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+FROM quay.io/strimzi/operator:0.41.0
+USER root
+RUN microdnf -y update && microdnf clean all
+USER 1001


### PR DESCRIPTION
## Summary and Scope

Adding a container images for Strimzi kafka-operator 0.41.0 and related kafka (3.6.0, 3.6.1, 3.6.2, 3.7.0) and kafka-bridge(0.28.0) images for upgrading in CSM 1.6.
Note - Commenting out the mitigations for log4j vulnerabilities since the latest version of Kafka is using reload4j instead of log4j (Ref - https://kafka.apache.org/36/documentation.html#upgrade_320_notable)

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMPET-6936](https://jira-pro.it.hpe.com:8443/browse/CASMPET-6936)