### PR TITLE
CASMPET-7912 add github.com/kubernetes-sigs/cri-tools/v1.24.2/Dockerfile

### DIFF
--- a/.github/workflows/github.com.kubernetes-sigs.cri-tools.v1.24.2.yaml
+++ b/.github/workflows/github.com.kubernetes-sigs.cri-tools.v1.24.2.yaml
@@ -1,0 +1,54 @@
+#
+# MIT License
+#
+# (C) Copyright 2022, 2024 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+name: github.com/kubernetes-sigs/cri-tools:v1.24.2
+on:
+  push:
+    paths:
+      - .github/workflows/github.com.kubernetes-sigs.cri-tools.v1.24.2.yaml
+      - github.com/kubernetes-sigs/cri-tools/v1.24.2/**
+  workflow_dispatch:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      CONTEXT_PATH: github.com/kubernetes-sigs/cri-tools/v1.24.2
+      DOCKER_REPO: artifactory.algol60.net/csm-docker/${{ github.ref == 'refs/heads/main' && 'stable' || 'unstable' }}/github.com/kubernetes-sigs/cri-tools
+      DOCKER_TAG: v1.24.2
+    steps:
+      - name: build-sign-scan
+        uses: Cray-HPE/github-actions/build-sign-scan@build-sign-scan/v2
+        with:
+          context_path: ${{ env.CONTEXT_PATH }}
+          docker_repo: ${{ env.DOCKER_REPO }}
+          docker_tag: ${{ env.DOCKER_TAG }}
+          docker_username: ${{ secrets.ARTIFACTORY_ALGOL60_USERNAME }}
+          docker_password: ${{ secrets.ARTIFACTORY_ALGOL60_TOKEN }}
+          sign: ${{ github.ref == 'refs/heads/main' }}
+          cosign_gcp_workload_identity_provider: ${{ secrets.COSIGN_GCP_WORKLOAD_IDENTITY_PROVIDER_RSA }}
+          cosign_gcp_service_account: ${{ secrets.COSIGN_GCP_SERVICE_ACCOUNT_RSA }}
+          cosign_key: ${{ secrets.COSIGN_KEY_RSA }}
+          snyk_token: ${{ secrets.SNYK_TOKEN }}

--- a/github.com/kubernetes-sigs/cri-tools/v1.24.2/Dockerfile
+++ b/github.com/kubernetes-sigs/cri-tools/v1.24.2/Dockerfile
@@ -1,0 +1,30 @@
+#
+# MIT License
+#
+# (C) Copyright [2024] Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+FROM artifactory.algol60.net/docker.io/alpine AS crictl
+
+RUN wget -O- https://github.com/kubernetes-sigs/cri-tools/releases/download/v1.24.2/crictl-v1.24.2-linux-amd64.tar.gz \
+    | tar -C /usr/bin -xvzf - crictl \
+    && chmod +x /usr/bin/crictl
+
+RUN   echo "runtime-endpoint: unix:///run/containerd/containerd.sock" >> /etc/crictl.yaml


### PR DESCRIPTION
## Summary and Scope

Create github.com/kubernetes-sigs/cri-tools/v1.24.2/Dockerfile. This creates a container image with 'crictl' which can be used for cray-preached-images and cray-drydock.

This container image is necessary in CSM 1.6 because in the K8s 1.24/SLES 15 SP6 build, cray-precache-images no longer works. The cray-precached-images container is not able to access the crictl binary on the host. This container image means that the cray-precached-images container won't need to access the crictl on the host.

## Issues and Related PRs

* Resolves [CASMPET-7912](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7912)
* Resolves [CASMTRIAGE-7227](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-7227)

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * Fanta with SP6 and k8s 1.24

### Test description:

Upgraded the cray-precached-images chart and saw that images were able to be pulled.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

