### PR TITLE
CASMPET-7292: Fix OPA Envoy plugin base images

### DIFF
--- a/docker.io/openpolicyagent/opa/0.52.0-envoy-rootless/Dockerfile
+++ b/docker.io/openpolicyagent/opa/0.52.0-envoy-rootless/Dockerfile
@@ -27,7 +27,7 @@ RUN git clone https://github.com/open-policy-agent/opa-envoy-plugin /opt/opa-env
   && git checkout v0.52.0-envoy\
   && GOOS=linux WASM_ENABLED=0 CGO_ENABLED=0 make
 
-FROM cgr.dev/chainguard/cc-dynamic:latest
+FROM cgr.dev/chainguard/glibc-dynamic:latest
 USER 1000:1000
 COPY --from=builder /opt/opa-envoy-plugin/opa_envoy_linux_amd64 /app/opa_envoy_linux_amd64
 WORKDIR /app

--- a/docker.io/openpolicyagent/opa/0.52.0-envoy-rootless/Dockerfile
+++ b/docker.io/openpolicyagent/opa/0.52.0-envoy-rootless/Dockerfile
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright [2023] Hewlett Packard Enterprise Development LP
+# (C) Copyright [2023,2024] Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),

--- a/docker.io/openpolicyagent/opa/0.62.0-envoy-rootless/Dockerfile
+++ b/docker.io/openpolicyagent/opa/0.62.0-envoy-rootless/Dockerfile
@@ -27,7 +27,7 @@ RUN git clone https://github.com/open-policy-agent/opa-envoy-plugin /opt/opa-env
   && git checkout v0.62.0-envoy\
   && GOOS=linux WASM_ENABLED=0 CGO_ENABLED=0 make
 
-FROM cgr.dev/chainguard/cc-dynamic:latest
+FROM cgr.dev/chainguard/glibc-dynamic:latest
 USER 1000:1000
 COPY --from=builder /opt/opa-envoy-plugin/opa_envoy_linux_amd64 /app/opa_envoy_linux_amd64
 WORKDIR /app


### PR DESCRIPTION
## Summary and Scope

This changeset updates the Open Policy Agent Envoy plugin images, 0.52.0 and 0.62.0, to build from `chainguard/glibc-dynamic` as a base instead of `chainguard/cc-dynamic`, as [cc-dynamic is no longer publicly available](https://support.chainguard.dev/hc/en-us/articles/28452542784667-Customer-Notice-Free-Image-Tier-Changes). [glibc-dynamic](https://console.chainguard.dev/org/hpe.com/images/public/image/glibc-dynamic/sbom) includes all of the same packages as [cc-dynamic](https://console.chainguard.dev/org/hpe.com/images/public/image/cc-dynamic/sbom), with the addition of `libstdc++`.

# Testing

The branch-specific GitHub Actions that run to build both of these images have both completed successfully: [0.52.0](https://github.com/Cray-HPE/container-images/actions/runs/12203631898), [0.62.0](https://github.com/Cray-HPE/container-images/actions/runs/12203631897).

## Issues and Related PRs

* Resolves [CASMPET-7292](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7292)

## Risks and Mitigations

The risk of this change seems low, given that the new image should be a strict superset of the functionality provided by the old image, and thus the OPA Envoy plugin ought to continue to build correctly.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

