### PR TITLE
CASMPET-7296 fix docker build for image quay.io/cephcsi/cephcsi/v3.6.2

### DIFF
--- a/quay.io/cephcsi/cephcsi/v3.6.2/Dockerfile
+++ b/quay.io/cephcsi/cephcsi/v3.6.2/Dockerfile
@@ -27,7 +27,8 @@ RUN dnf config-manager --disable tcmu-runner,tcmu-runner-noarch,tcmu-runner-sour
 
 # CentOS Stream 8 reached EOL and moved to http://vault.centos.org
 RUN sed -i -e 's|mirrorlist=http://mirrorlist.centos.org/|#mirrorlist=http://mirrorlist.centos.org/|' /etc/yum.repos.d/* \
-    && sed -i -e 's|#baseurl=http://mirror.centos.org/|baseurl=http://vault.centos.org/|' /etc/yum.repos.d/* \
+    && sed -i -e 's|#baseurl=http://mirror.centos.org/|baseurl=https://vault.centos.org/|' /etc/yum.repos.d/* \
+    && yum config-manager --disable 'Ceph*' ceph-source 'copr:*' epel epel-modular \
     && yum -y install yum-plugin-versionlock\
     && yum versionlock ceph*\
     && yum versionlock python3-ceph*\


### PR DESCRIPTION
## Summary and Scope

The container image builds had broken for `quay.io/cephcsi/cephcsi/v3.6.2`. This PR updates the Dockerfile so that the container image builds successfully.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMPET-7296](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7296)

## Testing

### Tested on:

  * Beau (vShasta2)

### Test description:

I used the new container image that was build in the k8s ceph-csi-cephfs and ceph-csi-rbd pods. I then created a PVC which uses ceph-csi-rbd and a PVC which uses ceph-csi-cephfs. The PVC were created successfully and pods were able to attach to the PVCs.

## Risks and Mitigations

Low risk

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

