### PR TITLE
CASMPET-7295 update quay.io/ceph/ceph/v17.2.6/Dockerfile to fix container image build

### DIFF
--- a/quay.io/ceph/ceph/v17.2.6/Dockerfile
+++ b/quay.io/ceph/ceph/v17.2.6/Dockerfile
@@ -25,7 +25,8 @@ FROM quay.io/ceph/ceph:v17.2.6
 
 # CentOS Stream 8 reached EOL and moved to http://vault.centos.org
 RUN sed -i -e 's|mirrorlist=http://mirrorlist.centos.org/|#mirrorlist=http://mirrorlist.centos.org/|' /etc/yum.repos.d/* \
-    && sed -i -e 's|#baseurl=http://mirror.centos.org/|baseurl=http://vault.centos.org/|' /etc/yum.repos.d/* \
+    && sed -i -e 's|#baseurl=http://mirror.centos.org/|baseurl=https://vault.centos.org/|' /etc/yum.repos.d/* \
+    && yum config-manager --disable 'Ceph*' ceph-source 'copr:*' epel \
     && yum install -y yum-plugin-versionlock\
     && yum versionlock ceph*\
     && yum versionlock python3-ceph*\
@@ -36,6 +37,6 @@ RUN sed -i -e 's|mirrorlist=http://mirrorlist.centos.org/|#mirrorlist=http://mir
     && yum versionlock python3-rgw*\
     && yum versionlock librgw*\
     && yum versionlock python3-rados*\
-    && yum versionlock librados*\
+    && yum versionlock librados*
 
 RUN yum -y upgrade && yum clean all


### PR DESCRIPTION
## Summary and Scope

The container image builds had broken for quay.io/ceph/ceph/v17.2.6. This PR updates the Dockerfile so that the container image builds successfully.

## Issues and Related PRs

* Resolves [CASMPET-7295](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7295)

## Testing


### Tested on:

  * Beau (vshasta2)

### Test description:

I updated ceph so that all ceph daemons used the new container image. I successfully created PVC and wrote data to them. Ceph worked properly with the new container image.

## Risks and Mitigations

Low risk

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

