### PR TITLE
CASM-5240: Add image for external-dns v0.15.0

### DIFF
--- a/.github/workflows/docker.io.bitnami.external-dns.0.15.0.yaml
+++ b/.github/workflows/docker.io.bitnami.external-dns.0.15.0.yaml
@@ -1,0 +1,59 @@
+#
+# MIT License
+#
+# (C) Copyright [2024] Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+
+# Generated with: make add IMAGE=bitnami/external-dns:0.15.0 REGISTRY=docker.io PACKAGE_MANAGER=
+#
+---
+name: docker.io/bitnami/external-dns:0.15.0
+on:
+  push:
+    paths:
+      - .github/workflows/docker.io.bitnami.external-dns.0.15.0.yaml
+      - docker.io/bitnami/external-dns/0.15.0/**
+  workflow_dispatch:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      CONTEXT_PATH: docker.io/bitnami/external-dns/0.15.0
+      DOCKER_REPO: artifactory.algol60.net/csm-docker/${{ github.ref == 'refs/heads/main' && 'stable' || 'unstable' }}/docker.io/bitnami/external-dns
+      DOCKER_TAG: 0.15.0
+    steps:
+      - name: build-sign-scan
+        uses: Cray-HPE/github-actions/build-sign-scan@build-sign-scan/v2
+        with:
+          context_path: ${{ env.CONTEXT_PATH }}
+          docker_repo: ${{ env.DOCKER_REPO }}
+          docker_tag: "${{ env.DOCKER_TAG }}"
+          docker_username: ${{ secrets.ARTIFACTORY_ALGOL60_USERNAME }}
+          docker_password: ${{ secrets.ARTIFACTORY_ALGOL60_TOKEN }}
+          sign: ${{ github.ref == 'refs/heads/main' }}
+          cosign_gcp_workload_identity_provider: ${{ secrets.COSIGN_GCP_WORKLOAD_IDENTITY_PROVIDER_RSA }}
+          cosign_gcp_service_account: ${{ secrets.COSIGN_GCP_SERVICE_ACCOUNT_RSA }}
+          cosign_key: ${{ secrets.COSIGN_KEY_RSA }}
+          snyk_token: ${{ secrets.SNYK_TOKEN }}
+          fail_on_snyk_errors: true

--- a/.github/workflows/docker.io.bitnami.external-dns.0.15.0.yaml
+++ b/.github/workflows/docker.io.bitnami.external-dns.0.15.0.yaml
@@ -56,4 +56,4 @@ jobs:
           cosign_gcp_service_account: ${{ secrets.COSIGN_GCP_SERVICE_ACCOUNT_RSA }}
           cosign_key: ${{ secrets.COSIGN_KEY_RSA }}
           snyk_token: ${{ secrets.SNYK_TOKEN }}
-          fail_on_snyk_errors: true
+          fail_on_snyk_errors: false

--- a/docker.io/bitnami/external-dns/0.15.0/Dockerfile
+++ b/docker.io/bitnami/external-dns/0.15.0/Dockerfile
@@ -21,7 +21,7 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
-FROM bitname/external-dns:0.15.0
+FROM bitnami/external-dns:0.15.0
 
 USER root
 RUN apt-get update && apt-get upgrade -y && apt full-upgrade -y \

--- a/docker.io/bitnami/external-dns/0.15.0/Dockerfile
+++ b/docker.io/bitnami/external-dns/0.15.0/Dockerfile
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright [2024] Hewlett Packard Enterprise Development LP
+# (C) Copyright [2025] Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -21,7 +21,9 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
+FROM bitname/external-dns:0.15.0
 
-# Generated with: make add IMAGE=bitnami/external-dns:0.15.0 REGISTRY=docker.io PACKAGE_MANAGER=
-#
-FROM docker.io/bitnami/external-dns:0.15.0
+USER root
+RUN apt-get update && apt-get upgrade -y && apt full-upgrade -y \
+    && rm -rf /var/lib/apt/lists/*
+USER 1001

--- a/docker.io/bitnami/external-dns/0.15.0/Dockerfile
+++ b/docker.io/bitnami/external-dns/0.15.0/Dockerfile
@@ -1,0 +1,27 @@
+#
+# MIT License
+#
+# (C) Copyright [2024] Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+
+# Generated with: make add IMAGE=bitnami/external-dns:0.15.0 REGISTRY=docker.io PACKAGE_MANAGER=
+#
+FROM docker.io/bitnami/external-dns:0.15.0


### PR DESCRIPTION
## Summary and Scope

Add external-dns v0.15.0 image for use in CSM 1.7.

## Issues and Related PRs

* Related to [CASM-5240](https://jira-pro.it.hpe.com:8443/browse/CASM-5240)
* [Chart update PR](https://github.com/Cray-HPE/cray-externaldns/pull/6)

## Testing

### Tested on:

  * Beau
  * Mug

### Test description:

  * Tested deleting an external-dns domain and then ensuring that it gets recreated
    * example below:
```
ncn-m001:~/mcdonald/cray-externaldns # kubectl get pods -A | grep external-dns
services         cray-externaldns-external-dns-5dfdc8b956-pzx7f                    1/1     Running                  0                   31s
ncn-m001:~/mcdonald/cray-externaldns # kubectl describe pod cray-externaldns-external-dns-5dfdc8b956-pzx7f -n services | grep Image
    Image:         artifactory.algol60.net/csm-docker/stable/docker.io/bitnami/external-dns:0.15.0
ncn-m001:~/mcdonald/cray-externaldns # kubectl -n services exec -it deployment/cray-dns-powerdns -- sh
/ $ pdnsutil list-all-zones
hmnlb
252.10.in-addr.arpa
hmn
cmn
nmn
hsn.mug.hpc.amslabs.hpecorp.net
hsn
mtl
nmnlb
can
107.10.in-addr.arpa
253.10.in-addr.arpa
106.10.in-addr.arpa
mtl.mug.hpc.amslabs.hpecorp.net
254.10.in-addr.arpa
nmn.mug.hpc.amslabs.hpecorp.net
100.94.10.in-addr.arpa
100.92.10.in-addr.arpa
hmnlb.mug.hpc.amslabs.hpecorp.net
nmnlb.mug.hpc.amslabs.hpecorp.net
can.mug.hpc.amslabs.hpecorp.net
162.102.10.in-addr.arpa
cmn.mug.hpc.amslabs.hpecorp.net
hmn.mug.hpc.amslabs.hpecorp.net
mug.hpc.amslabs.hpecorp.net
1.10.in-addr.arpa
/ $ pdnsutil delete-zone cmn.mug.hpc.amslabs.hpecorp.net
/ $ pdnsutil list-zone cmn.mug.hpc.amslabs.hpecorp.net | grep nexus.cmn
Zone 'cmn.mug.hpc.amslabs.hpecorp.net' not found!
/ $ pdnsutil list-zone cmn.mug.hpc.amslabs.hpecorp.net | grep nexus.cmn
a-nexus.cmn.mug.hpc.amslabs.hpecorp.net 300     IN      TXT     "heritage=external-dns,external-dns/owner=default,external-dns/resource=service/istio-system/istio-ingressgateway-cmn"
nexus.cmn.mug.hpc.amslabs.hpecorp.net   300     IN      A       10.102.162.65
nexus.cmn.mug.hpc.amslabs.hpecorp.net   300     IN      TXT     "heritage=external-dns,external-dns/owner=default,external-dns/resource=service/istio-system/istio-ingressgateway-cmn"
```

## Risks and Mitigations

None


## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable
