### PR TITLE
CASMHMS-5678: Create arm64 Alpine 3.21 image

### DIFF
--- a/.github/workflows/docker.io.library.alpine.3.21.yaml
+++ b/.github/workflows/docker.io.library.alpine.3.21.yaml
@@ -49,6 +49,7 @@ jobs:
           context_path: ${{ env.CONTEXT_PATH }}
           docker_repo: ${{ env.DOCKER_REPO }}
           docker_tag: ${{ env.DOCKER_TAG }}
+          docker_build_platforms: linux/arm64,linux/amd64
           docker_username: ${{ secrets.ARTIFACTORY_ALGOL60_USERNAME }}
           docker_password: ${{ secrets.ARTIFACTORY_ALGOL60_TOKEN }}
           sign: ${{ github.ref == 'refs/heads/main' }}

--- a/.github/workflows/docker.io.library.alpine.3.21.yaml
+++ b/.github/workflows/docker.io.library.alpine.3.21.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright [2024] Hewlett Packard Enterprise Development LP
+# (C) Copyright [2024-2025] Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),

--- a/README.md
+++ b/README.md
@@ -39,6 +39,35 @@ You may also set `V=1` for more output as far as what make is doing as well as o
 > git push
 ```
 
+## What are the steps to modify attributes of an existing image?
+
+Edit the GitHub workflow you wish to modify.  In the example below we make a change to produce ARM images:
+
+```text
+> vi .github/workflows/docker.io.library.alpine.3.21.yaml
+> git diff
+diff --git a/.github/workflows/docker.io.library.alpine.3.21.yaml b/.github/workflows/docker.io.library.alpine.3.21.yaml
+index aedcdb64..bef618fb 100644
+--- a/.github/workflows/docker.io.library.alpine.3.21.yaml
++++ b/.github/workflows/docker.io.library.alpine.3.21.yaml
+@@ -49,6 +49,7 @@ jobs:
+           context_path: ${{ env.CONTEXT_PATH }}
+           docker_repo: ${{ env.DOCKER_REPO }}
+           docker_tag: ${{ env.DOCKER_TAG }}
++          docker_build_platforms: linux/arm64,linux/amd64
+           docker_username: ${{ secrets.ARTIFACTORY_ALGOL60_USERNAME }}
+           docker_password: ${{ secrets.ARTIFACTORY_ALGOL60_TOKEN }}
+           sign: ${{ github.ref == 'refs/heads/main' }}
+```
+
+Do not run ```make add```.  Just commit and push:
+
+```text
+> vi .github/workflows/docker.io.library.alpine.3.21.yaml
+> git commit -a
+> git push
+```
+
 ## Naming conventions
 
 Base images can come from multiple places docker.io, quay.io, or arti (both custom and original community cached images). Some images are also ???


### PR DESCRIPTION
## Summary and Scope

We need an arm64 Alpine 3.21 image to support building on Apple ARM laptops.

## Issues and Related PRs

* Resolves [CASMHMS-5678](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-5678)

## Testing

No testing required outside of pipeline build tests

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

