### PR TITLE
CASM-5241: Add image for vault-operator v1.22.5

### DIFF
--- a/.github/workflows/ghcr.io.bank-vaults.vault-operator.v1.22.5.yaml
+++ b/.github/workflows/ghcr.io.bank-vaults.vault-operator.v1.22.5.yaml
@@ -1,0 +1,59 @@
+#
+# MIT License
+#
+# (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+
+# Generated with: make add IMAGE=bank-vaults/vault-operator:v1.22.5 REGISTRY=ghcr.io PACKAGE_MANAGER=
+#
+---
+name: ghcr.io/bank-vaults/vault-operator:v1.22.5
+on:
+  push:
+    paths:
+      - .github/workflows/ghcr.io.bank-vaults.vault-operator.v1.22.5.yaml
+      - ghcr.io/bank-vaults/vault-operator/v1.22.5/**
+  workflow_dispatch:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      CONTEXT_PATH: ghcr.io/bank-vaults/vault-operator/v1.22.5
+      DOCKER_REPO: artifactory.algol60.net/csm-docker/${{ github.ref == 'refs/heads/main' && 'stable' || 'unstable' }}/ghcr.io/bank-vaults/vault-operator
+      DOCKER_TAG: "v1.22.5"
+    steps:
+      - name: build-sign-scan
+        uses: Cray-HPE/github-actions/build-sign-scan@build-sign-scan/v2
+        with:
+          context_path: ${{ env.CONTEXT_PATH }}
+          docker_repo: ${{ env.DOCKER_REPO }}
+          docker_tag: "${{ env.DOCKER_TAG }}"
+          docker_username: ${{ secrets.ARTIFACTORY_ALGOL60_USERNAME }}
+          docker_password: ${{ secrets.ARTIFACTORY_ALGOL60_TOKEN }}
+          sign: ${{ github.ref == 'refs/heads/main' }}
+          cosign_gcp_workload_identity_provider: ${{ secrets.COSIGN_GCP_WORKLOAD_IDENTITY_PROVIDER_RSA }}
+          cosign_gcp_service_account: ${{ secrets.COSIGN_GCP_SERVICE_ACCOUNT_RSA }}
+          cosign_key: ${{ secrets.COSIGN_KEY_RSA }}
+          snyk_token: ${{ secrets.SNYK_TOKEN }}
+          fail_on_snyk_errors: true

--- a/ghcr.io/bank-vaults/vault-operator/v1.22.5/Dockerfile
+++ b/ghcr.io/bank-vaults/vault-operator/v1.22.5/Dockerfile
@@ -1,0 +1,39 @@
+#
+# MIT License
+#
+# (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+FROM ghcr.io/bank-vaults/vault-operator:v1.22.5 AS upstream
+
+FROM artifactory.algol60.net/docker.io/library/alpine
+
+RUN apk update && \
+    apk add --upgrade --no-cache \
+        apk-tools \
+        ca-certificates && \
+    apk -U upgrade && \
+    rm -rf /var/cache/apk/*
+
+COPY --from=upstream /usr/local/bin/vault-operator /usr/local/bin/vault-operator
+
+USER 65534
+
+ENTRYPOINT ["/usr/local/bin/vault-operator"]


### PR DESCRIPTION
## Summary and Scope

Add vault operator latest v1.22.5 image. Previously. I had merged https://github.com/Cray-HPE/container-images/pull/652, but that was a mistake by me, where I did not realize at the time that the repository the image was hosted on had changed, so that image is outdated. This is the correct image. 

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Part of [CASM-5241](https://jira-pro.it.hpe.com:8443/browse/CASM-5241)

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * Virtual Shasta

### Test description:

```
# kubectl describe pod cray-vault-operator-78f556dbc9-c2sxl -n vault | grep Image
    Image:         artifactory.algol60.net/csm-docker/stable/ghcr.io/bank-vaults/vault-operator:v1.22.5
```

## Risks and Mitigations

Low risk

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

