### PR TITLE
CASMPET-7376: Add kiali-operator image v2.10.0 for upgrade

### DIFF
--- a/.github/workflows/quay.io.kiali.kiali-operator.v2.10.0.yaml
+++ b/.github/workflows/quay.io.kiali.kiali-operator.v2.10.0.yaml
@@ -1,0 +1,58 @@
+#
+# MIT License
+#
+# (C) Copyright [2025] Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+
+# Generated with: make add IMAGE=kiali/kiali-operator:v2.10.0 REGISTRY=quay.io PACKAGE_MANAGER=
+#
+---
+name: quay.io/kiali/kiali-operator:v2.10.0
+on:
+  push:
+    paths:
+      - .github/workflows/quay.io.kiali.kiali-operator.v2.10.0.yaml
+      - quay.io/kiali/kiali-operator/v2.10.0/**
+  workflow_dispatch:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      CONTEXT_PATH: quay.io/kiali/kiali-operator/v2.10.0
+      DOCKER_REPO: artifactory.algol60.net/csm-docker/${{ github.ref == 'refs/heads/main' && 'stable' || 'unstable' }}/quay.io/kiali/kiali-operator
+      DOCKER_TAG: "v2.10.0"
+    steps:
+      - name: build-sign-scan
+        uses: Cray-HPE/github-actions/build-sign-scan@build-sign-scan/v2
+        with:
+          context_path: ${{ env.CONTEXT_PATH }}
+          docker_repo: ${{ env.DOCKER_REPO }}
+          docker_tag: "${{ env.DOCKER_TAG }}"
+          docker_username: ${{ secrets.ARTIFACTORY_ALGOL60_USERNAME }}
+          docker_password: ${{ secrets.ARTIFACTORY_ALGOL60_TOKEN }}
+          sign: ${{ github.ref == 'refs/heads/main' }}
+          cosign_gcp_workload_identity_provider: ${{ secrets.COSIGN_GCP_WORKLOAD_IDENTITY_PROVIDER_RSA }}
+          cosign_gcp_service_account: ${{ secrets.COSIGN_GCP_SERVICE_ACCOUNT_RSA }}
+          cosign_key: ${{ secrets.COSIGN_KEY_RSA }}
+          snyk_token: ${{ secrets.SNYK_TOKEN }}

--- a/.github/workflows/quay.io.kiali.kiali.v2.10.0.yaml
+++ b/.github/workflows/quay.io.kiali.kiali.v2.10.0.yaml
@@ -1,0 +1,58 @@
+#
+# MIT License
+#
+# (C) Copyright [2025] Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+
+# Generated with: make add IMAGE=kiali/kiali:v2.10.0 REGISTRY=quay.io PACKAGE_MANAGER=
+#
+---
+name: quay.io/kiali/kiali:v2.10.0
+on:
+  push:
+    paths:
+      - .github/workflows/quay.io.kiali.kiali.v2.10.0.yaml
+      - quay.io/kiali/kiali/v2.10.0/**
+  workflow_dispatch:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      CONTEXT_PATH: quay.io/kiali/kiali/v2.10.0
+      DOCKER_REPO: artifactory.algol60.net/csm-docker/${{ github.ref == 'refs/heads/main' && 'stable' || 'unstable' }}/quay.io/kiali/kiali
+      DOCKER_TAG: "v2.10.0"
+    steps:
+      - name: build-sign-scan
+        uses: Cray-HPE/github-actions/build-sign-scan@build-sign-scan/v2
+        with:
+          context_path: ${{ env.CONTEXT_PATH }}
+          docker_repo: ${{ env.DOCKER_REPO }}
+          docker_tag: "${{ env.DOCKER_TAG }}"
+          docker_username: ${{ secrets.ARTIFACTORY_ALGOL60_USERNAME }}
+          docker_password: ${{ secrets.ARTIFACTORY_ALGOL60_TOKEN }}
+          sign: ${{ github.ref == 'refs/heads/main' }}
+          cosign_gcp_workload_identity_provider: ${{ secrets.COSIGN_GCP_WORKLOAD_IDENTITY_PROVIDER_RSA }}
+          cosign_gcp_service_account: ${{ secrets.COSIGN_GCP_SERVICE_ACCOUNT_RSA }}
+          cosign_key: ${{ secrets.COSIGN_KEY_RSA }}
+          snyk_token: ${{ secrets.SNYK_TOKEN }}

--- a/quay.io/kiali/kiali-operator/v2.10.0/Dockerfile
+++ b/quay.io/kiali/kiali-operator/v2.10.0/Dockerfile
@@ -1,0 +1,45 @@
+#
+# MIT License
+#
+# (C) Copyright [2025] Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+FROM quay.io/kiali/kiali-operator:v2.10.0 AS base
+
+# Rebuild operator image with newer base image
+FROM quay.io/openshift/origin-ansible-operator:4.16
+
+USER root
+# See https://github.com/operator-framework/operator-sdk/issues/5745
+RUN yum remove -y subscription-manager python3-subscription-manager-rhsm && \
+    yum update -y && \
+    yum install -y python3-setuptools && \
+    yum clean all
+USER ${USER_UID}
+
+COPY --from=base ${HOME}/roles/ ${HOME}/roles/
+COPY --from=base ${HOME}/playbooks/ ${HOME}/playbooks/
+COPY --from=base ${HOME}/watches-k8s.yaml ${HOME}/watches-k8s.yaml
+
+COPY --from=base ${HOME}/requirements.yml ${HOME}/requirements.yml
+RUN ansible-galaxy collection install -r ${HOME}/requirements.yml --force \
+ && chmod -R ug+rwx ${HOME}/.ansible
+
+RUN cp /etc/ansible/ansible.cfg ${HOME}/ansible-profiler.cfg && echo "callbacks_enabled = profile_tasks" >> ${HOME}/ansible-profiler.cfg && echo "callback_whitelist = profile_tasks" >> ${HOME}/ansible-profiler.cfg

--- a/quay.io/kiali/kiali/v2.10.0/Dockerfile
+++ b/quay.io/kiali/kiali/v2.10.0/Dockerfile
@@ -1,0 +1,41 @@
+#
+# MIT License
+#
+# (C) Copyright [2025] Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+FROM quay.io/kiali/kiali:v2.10.0 AS base
+
+## distroless
+FROM gcr.io/distroless/static
+
+USER 1000
+
+ENV KIALI_HOME=/opt/kiali \
+    PATH=$KIALI_HOME:$PATH
+
+WORKDIR $KIALI_HOME
+
+COPY --chown=1000:1000 --from=base $KIALI_HOME/kiali $KIALI_HOME/
+
+COPY --chown=1000:1000 --from=base $KIALI_HOME/console/ $KIALI_HOME/console/
+
+ENTRYPOINT ["/opt/kiali/kiali"]
+


### PR DESCRIPTION
## Summary and Scope

Add kiali-operator image v2.10.0 for upgrade in CSM 1.7.

## Issues and Related PRs

* Related to [CASMPET-7376](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7376)
* Chart PR: https://github.com/Cray-HPE/cray-kiali/pull/15

## Testing

### Tested on:

  * Virtual Shasta

### Test description:

Running the following script:
```
#!/bin/bash

kubectl get pods -n istio-system | grep kiali

kubectl port-forward svc/kiali -n istio-system 20001:20001 &
PORT_FORWARD_PID=$!

sleep 5

# Fetch Kiali metrics
echo "Fetching Kiali metrics..."
curl -s http://localhost:20001/kiali/api/namespaces | head -c 50
echo ''

kill $PORT_FORWARD_PID
```

Resulted in the following output:
```
# ./test-kiali.sh
kiali-6fc596d955-779b6                                 1/1     Running   0          20h
Forwarding from 127.0.0.1:20001 -> 20001
Forwarding from [::1]:20001 -> 20001
Fetching Kiali metrics...
Handling connection for 20001
[{"name":"argo","cluster":"Kubernetes","isAmbient"
```

Tested before and after upgrade:
```
# kubectl describe pod -n operators cray-kiali-kiali-operator-bd69d5879-w6482 | grep Image
    Image:         artifactory.algol60.net/csm-docker/stable/quay.io/kiali/kiali-operator:v2.10.0
```

## Risks and Mitigations

None

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

