### PR TITLE
CASMPET-7382: Add strimzi-kafka-operator v0.45.0 for CSM 1.7

### DIFF
--- a/.github/workflows/quay.io.strimzi.kafka-bridge.0.31.1.yaml
+++ b/.github/workflows/quay.io.strimzi.kafka-bridge.0.31.1.yaml
@@ -1,0 +1,59 @@
+#
+# MIT License
+#
+# (C) Copyright [2025] Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+
+# Generated with: make add IMAGE=strimzi/kafka-bridge:0.31.1 REGISTRY=quay.io PACKAGE_MANAGER=
+#
+---
+name: quay.io/strimzi/kafka-bridge:0.31.1
+on:
+  push:
+    paths:
+      - .github/workflows/quay.io.strimzi.kafka-bridge.0.31.1.yaml
+      - quay.io/strimzi/kafka-bridge/0.31.1/**
+  workflow_dispatch:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      CONTEXT_PATH: quay.io/strimzi/kafka-bridge/0.31.1
+      DOCKER_REPO: artifactory.algol60.net/csm-docker/${{ github.ref == 'refs/heads/main' && 'stable' || 'unstable' }}/quay.io/strimzi/kafka-bridge
+      DOCKER_TAG: "0.31.1"
+    steps:
+      - name: build-sign-scan
+        uses: Cray-HPE/github-actions/build-sign-scan@build-sign-scan/v2
+        with:
+          context_path: ${{ env.CONTEXT_PATH }}
+          docker_repo: ${{ env.DOCKER_REPO }}
+          docker_tag: "${{ env.DOCKER_TAG }}"
+          docker_username: ${{ secrets.ARTIFACTORY_ALGOL60_USERNAME }}
+          docker_password: ${{ secrets.ARTIFACTORY_ALGOL60_TOKEN }}
+          sign: ${{ github.ref == 'refs/heads/main' }}
+          cosign_gcp_workload_identity_provider: ${{ secrets.COSIGN_GCP_WORKLOAD_IDENTITY_PROVIDER_RSA }}
+          cosign_gcp_service_account: ${{ secrets.COSIGN_GCP_SERVICE_ACCOUNT_RSA }}
+          cosign_key: ${{ secrets.COSIGN_KEY_RSA }}
+          snyk_token: ${{ secrets.SNYK_TOKEN }}
+          fail_on_snyk_errors: true

--- a/.github/workflows/quay.io.strimzi.kafka.0.45.0-kafka-3.8.0.yaml
+++ b/.github/workflows/quay.io.strimzi.kafka.0.45.0-kafka-3.8.0.yaml
@@ -1,0 +1,59 @@
+#
+# MIT License
+#
+# (C) Copyright [2025] Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+
+# Generated with: make add IMAGE=strimzi/kafka:0.45.0-kafka-3.8.0 REGISTRY=quay.io PACKAGE_MANAGER=
+#
+---
+name: quay.io/strimzi/kafka:0.45.0-kafka-3.8.0
+on:
+  push:
+    paths:
+      - .github/workflows/quay.io.strimzi.kafka.0.45.0-kafka-3.8.0.yaml
+      - quay.io/strimzi/kafka/0.45.0-kafka-3.8.0/**
+  workflow_dispatch:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      CONTEXT_PATH: quay.io/strimzi/kafka/0.45.0-kafka-3.8.0
+      DOCKER_REPO: artifactory.algol60.net/csm-docker/${{ github.ref == 'refs/heads/main' && 'stable' || 'unstable' }}/quay.io/strimzi/kafka
+      DOCKER_TAG: "0.45.0-kafka-3.8.0"
+    steps:
+      - name: build-sign-scan
+        uses: Cray-HPE/github-actions/build-sign-scan@build-sign-scan/v2
+        with:
+          context_path: ${{ env.CONTEXT_PATH }}
+          docker_repo: ${{ env.DOCKER_REPO }}
+          docker_tag: "${{ env.DOCKER_TAG }}"
+          docker_username: ${{ secrets.ARTIFACTORY_ALGOL60_USERNAME }}
+          docker_password: ${{ secrets.ARTIFACTORY_ALGOL60_TOKEN }}
+          sign: ${{ github.ref == 'refs/heads/main' }}
+          cosign_gcp_workload_identity_provider: ${{ secrets.COSIGN_GCP_WORKLOAD_IDENTITY_PROVIDER_RSA }}
+          cosign_gcp_service_account: ${{ secrets.COSIGN_GCP_SERVICE_ACCOUNT_RSA }}
+          cosign_key: ${{ secrets.COSIGN_KEY_RSA }}
+          snyk_token: ${{ secrets.SNYK_TOKEN }}
+          fail_on_snyk_errors: true

--- a/.github/workflows/quay.io.strimzi.kafka.0.45.0-kafka-3.8.1.yaml
+++ b/.github/workflows/quay.io.strimzi.kafka.0.45.0-kafka-3.8.1.yaml
@@ -1,0 +1,59 @@
+#
+# MIT License
+#
+# (C) Copyright [2025] Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+
+# Generated with: make add IMAGE=strimzi/kafka:0.45.0-kafka-3.8.1 REGISTRY=quay.io PACKAGE_MANAGER=
+#
+---
+name: quay.io/strimzi/kafka:0.45.0-kafka-3.8.1
+on:
+  push:
+    paths:
+      - .github/workflows/quay.io.strimzi.kafka.0.45.0-kafka-3.8.1.yaml
+      - quay.io/strimzi/kafka/0.45.0-kafka-3.8.1/**
+  workflow_dispatch:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      CONTEXT_PATH: quay.io/strimzi/kafka/0.45.0-kafka-3.8.1
+      DOCKER_REPO: artifactory.algol60.net/csm-docker/${{ github.ref == 'refs/heads/main' && 'stable' || 'unstable' }}/quay.io/strimzi/kafka
+      DOCKER_TAG: "0.45.0-kafka-3.8.1"
+    steps:
+      - name: build-sign-scan
+        uses: Cray-HPE/github-actions/build-sign-scan@build-sign-scan/v2
+        with:
+          context_path: ${{ env.CONTEXT_PATH }}
+          docker_repo: ${{ env.DOCKER_REPO }}
+          docker_tag: "${{ env.DOCKER_TAG }}"
+          docker_username: ${{ secrets.ARTIFACTORY_ALGOL60_USERNAME }}
+          docker_password: ${{ secrets.ARTIFACTORY_ALGOL60_TOKEN }}
+          sign: ${{ github.ref == 'refs/heads/main' }}
+          cosign_gcp_workload_identity_provider: ${{ secrets.COSIGN_GCP_WORKLOAD_IDENTITY_PROVIDER_RSA }}
+          cosign_gcp_service_account: ${{ secrets.COSIGN_GCP_SERVICE_ACCOUNT_RSA }}
+          cosign_key: ${{ secrets.COSIGN_KEY_RSA }}
+          snyk_token: ${{ secrets.SNYK_TOKEN }}
+          fail_on_snyk_errors: true

--- a/.github/workflows/quay.io.strimzi.kafka.0.45.0-kafka-3.9.0.yaml
+++ b/.github/workflows/quay.io.strimzi.kafka.0.45.0-kafka-3.9.0.yaml
@@ -1,0 +1,59 @@
+#
+# MIT License
+#
+# (C) Copyright [2025] Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+
+# Generated with: make add IMAGE=strimzi/kafka:0.45.0-kafka-3.9.0 REGISTRY=quay.io PACKAGE_MANAGER=
+#
+---
+name: quay.io/strimzi/kafka:0.45.0-kafka-3.9.0
+on:
+  push:
+    paths:
+      - .github/workflows/quay.io.strimzi.kafka.0.45.0-kafka-3.9.0.yaml
+      - quay.io/strimzi/kafka/0.45.0-kafka-3.9.0/**
+  workflow_dispatch:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      CONTEXT_PATH: quay.io/strimzi/kafka/0.45.0-kafka-3.9.0
+      DOCKER_REPO: artifactory.algol60.net/csm-docker/${{ github.ref == 'refs/heads/main' && 'stable' || 'unstable' }}/quay.io/strimzi/kafka
+      DOCKER_TAG: "0.45.0-kafka-3.9.0"
+    steps:
+      - name: build-sign-scan
+        uses: Cray-HPE/github-actions/build-sign-scan@build-sign-scan/v2
+        with:
+          context_path: ${{ env.CONTEXT_PATH }}
+          docker_repo: ${{ env.DOCKER_REPO }}
+          docker_tag: "${{ env.DOCKER_TAG }}"
+          docker_username: ${{ secrets.ARTIFACTORY_ALGOL60_USERNAME }}
+          docker_password: ${{ secrets.ARTIFACTORY_ALGOL60_TOKEN }}
+          sign: ${{ github.ref == 'refs/heads/main' }}
+          cosign_gcp_workload_identity_provider: ${{ secrets.COSIGN_GCP_WORKLOAD_IDENTITY_PROVIDER_RSA }}
+          cosign_gcp_service_account: ${{ secrets.COSIGN_GCP_SERVICE_ACCOUNT_RSA }}
+          cosign_key: ${{ secrets.COSIGN_KEY_RSA }}
+          snyk_token: ${{ secrets.SNYK_TOKEN }}
+          fail_on_snyk_errors: true

--- a/.github/workflows/quay.io.strimzi.operator.0.45.0.yaml
+++ b/.github/workflows/quay.io.strimzi.operator.0.45.0.yaml
@@ -1,0 +1,59 @@
+#
+# MIT License
+#
+# (C) Copyright [2025] Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+
+# Generated with: make add IMAGE=strimzi/operator:0.45.0 REGISTRY=quay.io PACKAGE_MANAGER=
+#
+---
+name: quay.io/strimzi/operator:0.45.0
+on:
+  push:
+    paths:
+      - .github/workflows/quay.io.strimzi.operator.0.45.0.yaml
+      - quay.io/strimzi/operator/0.45.0/**
+  workflow_dispatch:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      CONTEXT_PATH: quay.io/strimzi/operator/0.45.0
+      DOCKER_REPO: artifactory.algol60.net/csm-docker/${{ github.ref == 'refs/heads/main' && 'stable' || 'unstable' }}/quay.io/strimzi/operator
+      DOCKER_TAG: "0.45.0"
+    steps:
+      - name: build-sign-scan
+        uses: Cray-HPE/github-actions/build-sign-scan@build-sign-scan/v2
+        with:
+          context_path: ${{ env.CONTEXT_PATH }}
+          docker_repo: ${{ env.DOCKER_REPO }}
+          docker_tag: "${{ env.DOCKER_TAG }}"
+          docker_username: ${{ secrets.ARTIFACTORY_ALGOL60_USERNAME }}
+          docker_password: ${{ secrets.ARTIFACTORY_ALGOL60_TOKEN }}
+          sign: ${{ github.ref == 'refs/heads/main' }}
+          cosign_gcp_workload_identity_provider: ${{ secrets.COSIGN_GCP_WORKLOAD_IDENTITY_PROVIDER_RSA }}
+          cosign_gcp_service_account: ${{ secrets.COSIGN_GCP_SERVICE_ACCOUNT_RSA }}
+          cosign_key: ${{ secrets.COSIGN_KEY_RSA }}
+          snyk_token: ${{ secrets.SNYK_TOKEN }}
+          fail_on_snyk_errors: true

--- a/quay.io/strimzi/kafka-bridge/0.31.1/Dockerfile
+++ b/quay.io/strimzi/kafka-bridge/0.31.1/Dockerfile
@@ -1,0 +1,27 @@
+#
+# MIT License
+#
+# (C) Copyright [2025] Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+FROM quay.io/strimzi/kafka-bridge:0.31.1
+USER root
+RUN microdnf -y update && microdnf clean all
+USER 1001

--- a/quay.io/strimzi/kafka/0.45.0-kafka-3.8.0/Dockerfile
+++ b/quay.io/strimzi/kafka/0.45.0-kafka-3.8.0/Dockerfile
@@ -1,0 +1,27 @@
+#
+# MIT License
+#
+# (C) Copyright [2025] Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+FROM quay.io/strimzi/kafka:0.45.0-kafka-3.8.0
+USER root
+RUN microdnf -y update && microdnf -y install zip && microdnf clean all
+USER 1001

--- a/quay.io/strimzi/kafka/0.45.0-kafka-3.8.1/Dockerfile
+++ b/quay.io/strimzi/kafka/0.45.0-kafka-3.8.1/Dockerfile
@@ -1,0 +1,27 @@
+#
+# MIT License
+#
+# (C) Copyright [2025] Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+FROM quay.io/strimzi/kafka:0.45.0-kafka-3.8.1
+USER root
+RUN microdnf -y update && microdnf -y install zip && microdnf clean all
+USER 1001

--- a/quay.io/strimzi/kafka/0.45.0-kafka-3.9.0/Dockerfile
+++ b/quay.io/strimzi/kafka/0.45.0-kafka-3.9.0/Dockerfile
@@ -1,0 +1,27 @@
+#
+# MIT License
+#
+# (C) Copyright [2025] Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+FROM quay.io/strimzi/kafka:0.45.0-kafka-3.9.0
+USER root
+RUN microdnf -y update && microdnf -y install zip && microdnf clean all
+USER 1001

--- a/quay.io/strimzi/operator/0.45.0/Dockerfile
+++ b/quay.io/strimzi/operator/0.45.0/Dockerfile
@@ -1,0 +1,27 @@
+#
+# MIT License
+#
+# (C) Copyright [2025] Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+FROM quay.io/strimzi/operator:0.45.0
+USER root
+RUN microdnf -y update && microdnf clean all
+USER 1001


### PR DESCRIPTION
## Summary and Scope

Add strimzi-kafka-operator v0.45.0 image for use in upgrade for CSM 1.7.

## Issues and Related PRs

* Related to [CASMPET-7382](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7382)
* Chart PR: https://github.com/Cray-HPE/cray-kafka-operator/pull/10
* Shared kafka PR: https://github.com/Cray-HPE/cray-shared-kafka/pull/13

## Testing

### Tested on:

  * Virtual Shasta

### Test description:

Previous image:
```
# kubectl describe deployment cray-shared-kafka-entity-operator -n services  | grep Image
    Image:      artifactory.algol60.net/csm-docker/stable/quay.io/strimzi/operator:0.41.0
    Image:      artifactory.algol60.net/csm-docker/stable/quay.io/strimzi/operator:0.41.0
# kubectl get crds | grep kafka.strimzi.io
kafkabridges.kafka.strimzi.io                         2025-02-06T21:00:26Z
kafkaconnectors.kafka.strimzi.io                      2025-02-06T21:00:26Z
kafkaconnects.kafka.strimzi.io                        2025-02-06T21:00:26Z
kafkamirrormaker2s.kafka.strimzi.io                   2025-02-06T21:00:26Z
kafkamirrormakers.kafka.strimzi.io                    2025-02-06T21:00:26Z
kafkanodepools.kafka.strimzi.io                       2025-02-06T21:00:26Z
kafkarebalances.kafka.strimzi.io                      2025-02-06T21:00:26Z
kafkas.kafka.strimzi.io                               2025-02-06T21:00:25Z
kafkatopics.kafka.strimzi.io                          2025-02-06T21:00:26Z
kafkausers.kafka.strimzi.io                           2025-02-06T21:00:26Z
```

All pods updated and using new images:
```
# kubectl get pods -A | grep strimzi
operators        strimzi-cluster-operator-6986698dc6-2ms4n                         1/1     Running            0                3m17s
# kubectl describe pod strimzi-cluster-operator-6986698dc6-2ms4n -n operators | grep Image
    Image:         artifactory.algol60.net/csm-docker/stable/quay.io/strimzi/operator:0.45.0
# kubectl get pods -A | grep kafka
services         cray-shared-kafka-entity-operator-6fdb8685b6-kjkfd                2/2     Running            0                21s
services         cray-shared-kafka-kafka-0                                         1/1     Running            0                108s
services         cray-shared-kafka-kafka-1                                         1/1     Running            0                78s
services         cray-shared-kafka-kafka-2                                         1/1     Running            0                51s
services         cray-shared-kafka-zookeeper-0                                     1/1     Running            0                2m20s
services         cray-shared-kafka-zookeeper-1                                     1/1     Running            0                3m36s
services         cray-shared-kafka-zookeeper-2                                     1/1     Running            0                3m2s
# kubectl describe pod -n services cray-shared-kafka-entity-operator-6fdb8685b6-kjkfd | grep Image
    Image:         artifactory.algol60.net/csm-docker/stable/quay.io/strimzi/operator:0.45.0
    Image:         artifactory.algol60.net/csm-docker/stable/quay.io/strimzi/operator:0.45.0
# kubectl describe pod cray-shared-kafka-kafka-0 -n services | grep Image
    Image:         artifactory.algol60.net/csm-docker/stable/quay.io/strimzi/kafka:0.45.0-kafka-3.9.0
# kubectl describe pod cray-shared-kafka-zookeeper-0 -n services | grep Image
    Image:         artifactory.algol60.net/csm-docker/stable/quay.io/strimzi/kafka:0.45.0-kafka-3.9.0
```

## Risks and Mitigations

Low.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

