### PR TITLE
CASMPET-7394 edit spilo-15:3.0-p1 container image to run as postgres user

### DIFF
--- a/ghcr.io/zalando/spilo-15/3.0-p1/Dockerfile
+++ b/ghcr.io/zalando/spilo-15/3.0-p1/Dockerfile
@@ -37,3 +37,5 @@ COPY ./pgq_ticker.ini /home/postgres/pgq_ticker.ini
 
 # Capture psql version and packages to the build logs
 RUN psql --version && dpkg -l
+
+USER 101:103


### PR DESCRIPTION
## Summary and Scope

Kyverno policies need to be updated in CSM 1.7. Postgres is currently violating these policies because it is running as root. This PR changes the container image so that it runs as the postgres USER.

The postgres user already exists in the container image.

```text
docker run --platform linux/amd64 -it --rm --entrypoint=bash ghcr.io/zalando/spilo-15:3.0-p1 -c 'id postgres'
uid=101(postgres) gid=103(postgres) groups=103(postgres),0(root),102(ssl-cert)
```
Postgres pods successfully run as postgres user.

```text
ncn-m001:~/leliasen # kubectl exec -it -n argo cray-nls-postgres-0 -- /bin/sh
$ id
uid=101(postgres) gid=103(postgres) groups=103(postgres),0(root),102(ssl-cert)
```

All postgres health checks passed when postgres pods were running as postgres user.

```text
PASSED. All postgresql checks passed.
```

## Issues and Related PRs

* Resolves [CASMPET-7394](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7394)

## Testing

### Tested on:

  * Beau

### Test description:

Edited the cray-postgres-operator chart so that the new spilo image with user postgres was used. I then upgraded the cray-postgres-operator chart on Beau and all postgres clusters restarted with the new image. All postgres clusters were healthy with the new image.

## Risks and Mitigations

Low risk

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

