### PR TITLE
CASMTRIAGE-7927: Update portainer image 

### DIFF
--- a/.github/workflows/docker.io.portainer.kubectl-shell.2.27.0.yaml
+++ b/.github/workflows/docker.io.portainer.kubectl-shell.2.27.0.yaml
@@ -1,0 +1,54 @@
+#
+# MIT License
+#
+# (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+name: docker.io/portainer/kubectl-shell:2.27.0
+on:
+  push:
+    paths:
+      - .github/workflows/docker.io.portainer.kubectl-shell.2.27.0.yaml
+      - docker.io/portainer/kubectl-shell/2.27.0/**
+  workflow_dispatch:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      CONTEXT_PATH: docker.io/portainer/kubectl-shell/2.27.0
+      DOCKER_REPO: artifactory.algol60.net/csm-docker/${{ github.ref == 'refs/heads/main' && 'stable' || 'unstable' }}/docker.io/portainer/kubectl-shell
+      DOCKER_TAG: 2.27.0
+    steps:
+      - name: build-sign-scan
+        uses: Cray-HPE/github-actions/build-sign-scan@build-sign-scan/v2
+        with:
+          context_path: ${{ env.CONTEXT_PATH }}
+          docker_repo: ${{ env.DOCKER_REPO }}
+          docker_tag: ${{ env.DOCKER_TAG }}
+          docker_username: ${{ secrets.ARTIFACTORY_ALGOL60_USERNAME }}
+          docker_password: ${{ secrets.ARTIFACTORY_ALGOL60_TOKEN }}
+          sign: ${{ github.ref == 'refs/heads/main' }}
+          cosign_gcp_workload_identity_provider: ${{ secrets.COSIGN_GCP_WORKLOAD_IDENTITY_PROVIDER_RSA }}
+          cosign_gcp_service_account: ${{ secrets.COSIGN_GCP_SERVICE_ACCOUNT_RSA }}
+          cosign_key: ${{ secrets.COSIGN_KEY_RSA }}
+          snyk_token: ${{ secrets.SNYK_TOKEN }}

--- a/docker.io/portainer/kubectl-shell/2.27.0/Dockerfile
+++ b/docker.io/portainer/kubectl-shell/2.27.0/Dockerfile
@@ -1,0 +1,31 @@
+#
+# MIT License
+#
+# (C) Copyright [2025] Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+FROM docker.io/portainer/kubectl-shell:2.27.0
+
+USER 0
+RUN apk add --upgrade apk-tools --no-cache && apk update --no-cache && apk --update-cache upgrade --no-cache && apk add --no-cache rpm2cpio cpio gcompat && rm -rf /var/cache/apk/*
+# use curl to download the rpm file
+RUN curl -L https://github.com/Cray-HPE/cray-site-init/releases/download/v1.36.8/cray-site-init-1.36.8-1.x86_64.noos.rpm -o /tmp/cray-site-init.rpm
+RUN cd /tmp && rpm2cpio cray-site-init.rpm | cpio -idmv && cp /tmp/usr/bin/csi /usr/local/bin/csi && rm -rf /tmp/*
+USER 1000

--- a/images.mk
+++ b/images.mk
@@ -191,6 +191,7 @@ DOCKERIMAGES:=docker.io/openpolicyagent/opa:0.26.0-envoy-6
 DOCKERIMAGES:=docker.io/openpolicyagent/opa:0.42.1-envoy
 DOCKERIMAGES:=docker.io/opensuse/leap:15.2
 DOCKERIMAGES:=docker.io/portainer/kubectl-shell:latest-v1.21.1-amd64
+DOCKERIMAGES:=docker.io/portainer/kubectl-shell:2.27.0
 DOCKERIMAGES:=docker.io/prom/prometheus:v2.19.2
 DOCKERIMAGES:=docker.io/prom/pushgateway:v0.8.0
 DOCKERIMAGES:=docker.io/prom/snmp-exporter:v0.20.0


### PR DESCRIPTION


## Summary and Scope

CASMTRIAGE-7927: Update portainer image  based on CSM 1.7 Kubernetes Version v1.32 and use latest cray-site-init version 1.36.8

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMTRIAGE-7927](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-7927)

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * `wasp`
  * Local development environment


### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were new tests (or test issues/Jiras) created for this change?
https://spiraplan-pro-ext.it.hpe.com/SpiraPlan/3714/TestCase/List.aspx

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_

No


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [ ] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

