### PR TITLE
USS-4434: Add Artemis 2.40.0 and operator images

### DIFF
--- a/.github/workflows/quay.io.arkmq-org.activemq-artemis-broker-init.2.0.2.yaml
+++ b/.github/workflows/quay.io.arkmq-org.activemq-artemis-broker-init.2.0.2.yaml
@@ -1,0 +1,58 @@
+#
+# MIT License
+#
+# (C) Copyright [2025] Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+
+# Generated with: make add IMAGE=arkmq-org/activemq-artemis-broker-init:2.0.2 REGISTRY=quay.io PACKAGE_MANAGER=microdnf
+#
+---
+name: quay.io/arkmq-org/activemq-artemis-broker-init:2.0.2
+on:
+  push:
+    paths:
+      - .github/workflows/quay.io.arkmq-org.activemq-artemis-broker-init.2.0.2.yaml
+      - quay.io/arkmq-org/activemq-artemis-broker-init/2.0.2/**
+  workflow_dispatch:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      CONTEXT_PATH: quay.io/arkmq-org/activemq-artemis-broker-init/2.0.2
+      DOCKER_REPO: artifactory.algol60.net/csm-docker/${{ github.ref == 'refs/heads/main' && 'stable' || 'unstable' }}/quay.io/arkmq-org/activemq-artemis-broker-init
+      DOCKER_TAG: "2.0.2"
+    steps:
+      - name: build-sign-scan
+        uses: Cray-HPE/github-actions/build-sign-scan@build-sign-scan/v2
+        with:
+          context_path: ${{ env.CONTEXT_PATH }}
+          docker_repo: ${{ env.DOCKER_REPO }}
+          docker_tag: "${{ env.DOCKER_TAG }}"
+          docker_username: ${{ secrets.ARTIFACTORY_ALGOL60_USERNAME }}
+          docker_password: ${{ secrets.ARTIFACTORY_ALGOL60_TOKEN }}
+          sign: ${{ github.ref == 'refs/heads/main' }}
+          cosign_gcp_workload_identity_provider: ${{ secrets.COSIGN_GCP_WORKLOAD_IDENTITY_PROVIDER_RSA }}
+          cosign_gcp_service_account: ${{ secrets.COSIGN_GCP_SERVICE_ACCOUNT_RSA }}
+          cosign_key: ${{ secrets.COSIGN_KEY_RSA }}
+          snyk_token: ${{ secrets.SNYK_TOKEN }}

--- a/.github/workflows/quay.io.arkmq-org.activemq-artemis-broker-kubernetes.2.0.3.yaml
+++ b/.github/workflows/quay.io.arkmq-org.activemq-artemis-broker-kubernetes.2.0.3.yaml
@@ -1,0 +1,58 @@
+#
+# MIT License
+#
+# (C) Copyright [2025] Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+
+# Generated with: make add IMAGE=arkmq-org/activemq-artemis-broker-kubernetes:2.0.3 REGISTRY=quay.io PACKAGE_MANAGER=microdnf
+#
+---
+name: quay.io/arkmq-org/activemq-artemis-broker-kubernetes:2.0.3
+on:
+  push:
+    paths:
+      - .github/workflows/quay.io.arkmq-org.activemq-artemis-broker-kubernetes.2.0.3.yaml
+      - quay.io/arkmq-org/activemq-artemis-broker-kubernetes/2.0.3/**
+  workflow_dispatch:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      CONTEXT_PATH: quay.io/arkmq-org/activemq-artemis-broker-kubernetes/2.0.3
+      DOCKER_REPO: artifactory.algol60.net/csm-docker/${{ github.ref == 'refs/heads/main' && 'stable' || 'unstable' }}/quay.io/arkmq-org/activemq-artemis-broker-kubernetes
+      DOCKER_TAG: "2.0.3"
+    steps:
+      - name: build-sign-scan
+        uses: Cray-HPE/github-actions/build-sign-scan@build-sign-scan/v2
+        with:
+          context_path: ${{ env.CONTEXT_PATH }}
+          docker_repo: ${{ env.DOCKER_REPO }}
+          docker_tag: "${{ env.DOCKER_TAG }}"
+          docker_username: ${{ secrets.ARTIFACTORY_ALGOL60_USERNAME }}
+          docker_password: ${{ secrets.ARTIFACTORY_ALGOL60_TOKEN }}
+          sign: ${{ github.ref == 'refs/heads/main' }}
+          cosign_gcp_workload_identity_provider: ${{ secrets.COSIGN_GCP_WORKLOAD_IDENTITY_PROVIDER_RSA }}
+          cosign_gcp_service_account: ${{ secrets.COSIGN_GCP_SERVICE_ACCOUNT_RSA }}
+          cosign_key: ${{ secrets.COSIGN_KEY_RSA }}
+          snyk_token: ${{ secrets.SNYK_TOKEN }}

--- a/.github/workflows/quay.io.arkmq-org.activemq-artemis-operator.2.0.2.yaml
+++ b/.github/workflows/quay.io.arkmq-org.activemq-artemis-operator.2.0.2.yaml
@@ -1,0 +1,58 @@
+#
+# MIT License
+#
+# (C) Copyright [2025] Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+
+# Generated with: make add IMAGE=arkmq-org/activemq-artemis-operator:2.0.2 REGISTRY=quay.io PACKAGE_MANAGER=microdnf
+#
+---
+name: quay.io/arkmq-org/activemq-artemis-operator:2.0.2
+on:
+  push:
+    paths:
+      - .github/workflows/quay.io.arkmq-org.activemq-artemis-operator.2.0.2.yaml
+      - quay.io/arkmq-org/activemq-artemis-operator/2.0.2/**
+  workflow_dispatch:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      CONTEXT_PATH: quay.io/arkmq-org/activemq-artemis-operator/2.0.2
+      DOCKER_REPO: artifactory.algol60.net/csm-docker/${{ github.ref == 'refs/heads/main' && 'stable' || 'unstable' }}/quay.io/arkmq-org/activemq-artemis-operator
+      DOCKER_TAG: "2.0.2"
+    steps:
+      - name: build-sign-scan
+        uses: Cray-HPE/github-actions/build-sign-scan@build-sign-scan/v2
+        with:
+          context_path: ${{ env.CONTEXT_PATH }}
+          docker_repo: ${{ env.DOCKER_REPO }}
+          docker_tag: "${{ env.DOCKER_TAG }}"
+          docker_username: ${{ secrets.ARTIFACTORY_ALGOL60_USERNAME }}
+          docker_password: ${{ secrets.ARTIFACTORY_ALGOL60_TOKEN }}
+          sign: ${{ github.ref == 'refs/heads/main' }}
+          cosign_gcp_workload_identity_provider: ${{ secrets.COSIGN_GCP_WORKLOAD_IDENTITY_PROVIDER_RSA }}
+          cosign_gcp_service_account: ${{ secrets.COSIGN_GCP_SERVICE_ACCOUNT_RSA }}
+          cosign_key: ${{ secrets.COSIGN_KEY_RSA }}
+          snyk_token: ${{ secrets.SNYK_TOKEN }}

--- a/quay.io/arkmq-org/activemq-artemis-broker-init/2.0.2/Dockerfile
+++ b/quay.io/arkmq-org/activemq-artemis-broker-init/2.0.2/Dockerfile
@@ -1,0 +1,30 @@
+#
+# MIT License
+#
+# (C) Copyright [2025] Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+
+# Generated with: make add IMAGE=arkmq-org/activemq-artemis-broker-init:2.0.2 REGISTRY=quay.io PACKAGE_MANAGER=microdnf
+#
+FROM quay.io/arkmq-org/activemq-artemis-broker-init:2.0.2
+USER root
+RUN microdnf update -y && microdnf clean all
+USER 185

--- a/quay.io/arkmq-org/activemq-artemis-broker-kubernetes/2.0.3/Dockerfile
+++ b/quay.io/arkmq-org/activemq-artemis-broker-kubernetes/2.0.3/Dockerfile
@@ -1,0 +1,30 @@
+#
+# MIT License
+#
+# (C) Copyright [2025] Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+
+# Generated with: make add IMAGE=arkmq-org/activemq-artemis-broker-kubernetes:2.0.3 REGISTRY=quay.io PACKAGE_MANAGER=microdnf
+#
+FROM quay.io/arkmq-org/activemq-artemis-broker-kubernetes:2.0.3
+USER root
+RUN microdnf update -y && microdnf clean all
+USER 185

--- a/quay.io/arkmq-org/activemq-artemis-operator/2.0.2/Dockerfile
+++ b/quay.io/arkmq-org/activemq-artemis-operator/2.0.2/Dockerfile
@@ -1,0 +1,30 @@
+#
+# MIT License
+#
+# (C) Copyright [2025] Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+
+# Generated with: make add IMAGE=arkmq-org/activemq-artemis-operator:2.0.2 REGISTRY=quay.io PACKAGE_MANAGER=microdnf
+#
+FROM quay.io/arkmq-org/activemq-artemis-operator:2.0.2
+USER root
+RUN microdnf update -y && microdnf clean all
+USER 185


### PR DESCRIPTION
## Summary and Scope

This PR updates the MQTT broker images used for DVS node health. The update is necessary to pickup a CVE that was discovered in the 2.39.0 version of the MQTT broker.
CVE-2025-27427: Apache ActiveMQ Artemis: Address routing-type can be updated by user without the createAddress permission
Affected versions:
Apache ActiveMQ Artemis 2.0.0 through 2.39.0
Description:
A vulnerability exists in Apache ActiveMQ Artemis whereby a user with the createDurableQueue or createNonDurableQueue permission on an address can augment the routing-type supported by that address even if said user doesn't have the createAddress permission for that particular address. When combined with the send permission and automatic queue creation a user could successfully send a message with a routing-type not supported by the address when that message should actually be rejected on the basis that the user doesn't have permission to change the routing-type of the address.
This issue affects Apache ActiveMQ Artemis from 2.0.0 through 2.39.0.
Users are recommended to upgrade to version 2.40.0 which fixes the issue.
This issue is being tracked as ARTEMIS-5346.

## Issues and Related PRs

Jiras USS-4436 and USS-4437 depend on this PR.

* Resolves CVE-2025-27427: Apache ActiveMQ Artemis: Address routing-type can be updated by user without the createAddress permission
* Change will also be needed in `git repos hpc-dvs-broker and hpc-shasta-os-uss-product-stream`
* Future work required by [USS-4436](https://jira-pro.it.hpe.com:8443/browse/USS-4436) and [USS-4437](https://jira-pro.it.hpe.com:8443/browse/USS-4437)
* Documentation changes required in [issue id](issue link)
* Merge with/before/after `<insert PR URL here>`

## Testing

Testing was on development systems by copying images and helm charts to test system and hand installing using skip and help upgrade cmds.

### Tested on:

  * `lemondrop (CSM 1.6.2, wasp (CSM 1.7.0-alpha.10)`
  * Local development environment
  * Virtual Shasta

### Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? No
- Were continuous integration tests run? If not, why? yes, on lemondrop
- Was upgrade tested? If not, why? yes using helm.
- Was downgrade tested? If not, why? no, don't want to go back it an insecure image.
- Were new tests (or test issues/Jiras) created for this change? No

## Risks and Mitigations

No issues found that affect DVS use of  MQTT broker functionality.
Ran through DVS MQTT broker  related tests. Also, release notes which lists known issues. https://activemq.apache.org/components/artemis/download/release-notes-2.40.0

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ x] Copyrights updated
- [ x] License file intact
- [ x] Target branch correct
- [ ] CHANGELOG.md updated
- [ x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

