### PR TITLE
CASMPET-7447: VPA charts use docker.io/library/bitnami/kubectl:1.28

### DIFF
--- a/.github/workflows/docker.io.library.bitnami.kubectl.1.28.yaml
+++ b/.github/workflows/docker.io.library.bitnami.kubectl.1.28.yaml
@@ -1,0 +1,61 @@
+#
+# MIT License
+#
+# (C) Copyright [2025] Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+
+# Generated with: make add IMAGE=bitnami/kubectl:1.28 REGISTRY=docker.io PACKAGE_MANAGER=apt
+# Manually modified the path from docker.io/bitnami/kubectl to docker.io/library/bitnami/kubectl
+# Manually renamed this file to docker.io.library.bitnami.kubectl.1.28.yaml
+#
+---
+name: docker.io/library/bitnami/kubectl:1.28
+on:
+  push:
+    paths:
+      - .github/workflows/docker.io.library.bitnami.kubectl.1.28.yaml
+      - docker.io/library/bitnami/kubectl/1.28/**
+  workflow_dispatch:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      CONTEXT_PATH: docker.io/library/bitnami/kubectl/1.28
+      DOCKER_REPO: artifactory.algol60.net/csm-docker/${{ github.ref == 'refs/heads/main' && 'stable' || 'unstable' }}/docker.io/library/bitnami/kubectl
+      DOCKER_TAG: "1.28"
+    steps:
+      - name: build-sign-scan
+        uses: Cray-HPE/github-actions/build-sign-scan@build-sign-scan/v2
+        with:
+          context_path: ${{ env.CONTEXT_PATH }}
+          docker_repo: ${{ env.DOCKER_REPO }}
+          docker_tag: "${{ env.DOCKER_TAG }}"
+          docker_username: ${{ secrets.ARTIFACTORY_ALGOL60_USERNAME }}
+          docker_password: ${{ secrets.ARTIFACTORY_ALGOL60_TOKEN }}
+          sign: ${{ github.ref == 'refs/heads/main' }}
+          cosign_gcp_workload_identity_provider: ${{ secrets.COSIGN_GCP_WORKLOAD_IDENTITY_PROVIDER_RSA }}
+          cosign_gcp_service_account: ${{ secrets.COSIGN_GCP_SERVICE_ACCOUNT_RSA }}
+          cosign_key: ${{ secrets.COSIGN_KEY_RSA }}
+          snyk_token: ${{ secrets.SNYK_TOKEN }}
+          fail_on_snyk_errors: true

--- a/docker.io/library/bitnami/kubectl/1.28/Dockerfile
+++ b/docker.io/library/bitnami/kubectl/1.28/Dockerfile
@@ -1,0 +1,35 @@
+#
+# MIT License
+#
+# (C) Copyright [2025] Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+
+# Generated with: make add IMAGE=bitnami/kubectl:1.28 REGISTRY=docker.io PACKAGE_MANAGER=apt
+# Manually moved this file from docker.io/bitnami/kubectl/1.28
+# to docker.io/library/bitnami/kubectl/1.28
+#
+FROM docker.io/bitnami/kubectl:1.28
+
+# Manually added USER root and USER 1001, build failed otherwise
+USER root
+RUN apt-get -y update && apt-get upgrade -y && apt full-upgrade -y \
+    && rm -rf /var/lib/apt/lists/
+USER 1001


### PR DESCRIPTION
## Summary and Scope
The `cray-vpa` chart uses the VPA manifest from Fairwinds.  Some chart somewhere uses the `docker.io/library/bitnami/kubectl:1.28` image.  This causes CSM build to fail with:
```
2025-03-31T20:15:48.889Z] + skopeo-inspect docker://artifactory.algol60.net/csm-docker/stable/docker.io/library/bitnami/kubectl:1.28
[2025-03-31T20:15:48.889Z] time="2025-03-31T20:15:48Z" level=fatal msg="Error parsing image name \"docker://artifactory.algol60.net/csm-docker/stable/docker.io/library/bitnami/kubectl:1.28\": reading manifest 1.28 in artifactory.algol60.net/csm-docker/stable/docker.io/library/bitnami/kubectl: manifest unknown: The named manifest is not known to the registry."
[2025-03-31T20:15:48.889Z] parallel: This job failed:
[2025-03-31T20:15:48.889Z] ./inspect.sh 'bitnami/kubectl:1.28'
```

I found `kubectl:1.28` at `docker.io/bitnami/kubectl` and NOT at `docker.io/library/bitnami/kubectl:1.28`.

Generated files using `make add IMAGE=bitnami/kubectl:1.28 REGISTRY=docker.io` but then modified directory and file names to match `docker.io/library/bitnami/kubectl`.  

Image pushed to [csm-docker/unstable/docker.io/library/bitnami/kubectl/1.28/](https://artifactory.algol60.net/artifactory/csm-docker/unstable/docker.io/library/bitnami/kubectl/1.28/).

CASMPET-7447: VPA charts use docker.io/library/bitnami/kubectl:1.28 image
* Pull docker.io/bitnami/kubectl:1.28 but push to Artifactory at docker.io/libray/bitnami/kubectl:1.28
* Use root user before 'apt-get' then change to user 1001

## Issues and Related PRs

* Resolves [CASM-7447](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7447)

## Testing
Once this is merged, rerun csm PR and should work.

## Risks and Mitigations

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

