### PR TITLE
CASMPET-7447: cray-vpa Fairwinds chart now needs bitnami/kubectl:1.32

### DIFF
--- a/.github/workflows/docker.io.library.bitnami.kubectl.1.32.yaml
+++ b/.github/workflows/docker.io.library.bitnami.kubectl.1.32.yaml
@@ -1,0 +1,61 @@
+#
+# MIT License
+#
+# (C) Copyright [2025] Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+
+# Generated with: make add IMAGE=bitnami/kubectl:1.32 REGISTRY=docker.io PACKAGE_MANAGER=apt
+# Manually modified the path from docker.io/bitnami/kubectl to docker.io/library/bitnami/kubectl
+# Manually renamed this file to docker.io.library.bitnami.kubectl.1.32.yaml
+#
+---
+name: docker.io/library/bitnami/kubectl:1.32
+on:
+  push:
+    paths:
+      - .github/workflows/docker.io.library.bitnami.kubectl.1.32.yaml
+      - docker.io/library/bitnami/kubectl/1.32/**
+  workflow_dispatch:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      CONTEXT_PATH: docker.io/library/bitnami/kubectl/1.32
+      DOCKER_REPO: artifactory.algol60.net/csm-docker/${{ github.ref == 'refs/heads/main' && 'stable' || 'unstable' }}/docker.io/library/bitnami/kubectl
+      DOCKER_TAG: "1.32"
+    steps:
+      - name: build-sign-scan
+        uses: Cray-HPE/github-actions/build-sign-scan@build-sign-scan/v2
+        with:
+          context_path: ${{ env.CONTEXT_PATH }}
+          docker_repo: ${{ env.DOCKER_REPO }}
+          docker_tag: "${{ env.DOCKER_TAG }}"
+          docker_username: ${{ secrets.ARTIFACTORY_ALGOL60_USERNAME }}
+          docker_password: ${{ secrets.ARTIFACTORY_ALGOL60_TOKEN }}
+          sign: ${{ github.ref == 'refs/heads/main' }}
+          cosign_gcp_workload_identity_provider: ${{ secrets.COSIGN_GCP_WORKLOAD_IDENTITY_PROVIDER_RSA }}
+          cosign_gcp_service_account: ${{ secrets.COSIGN_GCP_SERVICE_ACCOUNT_RSA }}
+          cosign_key: ${{ secrets.COSIGN_KEY_RSA }}
+          snyk_token: ${{ secrets.SNYK_TOKEN }}
+          fail_on_snyk_errors: true

--- a/docker.io/library/bitnami/kubectl/1.32/Dockerfile
+++ b/docker.io/library/bitnami/kubectl/1.32/Dockerfile
@@ -1,0 +1,35 @@
+#
+# MIT License
+#
+# (C) Copyright [2025] Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+
+# Generated with: make add IMAGE=bitnami/kubectl:1.32 REGISTRY=docker.io PACKAGE_MANAGER=apt
+# Manually moved this file from docker.io/bitnami/kubectl/1.32
+# to docker.io/library/bitnami/kubectl/1.32
+#
+FROM docker.io/bitnami/kubectl:1.32
+
+# Manually added USER root and USER 1001, build failed otherwise
+USER root
+RUN apt-get -y update && apt-get upgrade -y && apt full-upgrade -y \
+    && rm -rf /var/lib/apt/lists/
+USER 1001


### PR DESCRIPTION
## Summary and Scope
Building CSM fails for `cray-vpa` because `bitnami/kubectl:1.32` image does not exist in Artifactory.  Not sure what is changing in the  Fairwinds vpa 4.7.2 chart for it to switch from `bitnami/kubectl:1.28` to `bitnami/kubectl:1.32`.  Will investigate.  Meanwhile, this is needed.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMPET-7447](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7447)

## Testing
CSM will build successfully.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

