### PR TITLE
CASMMON-520 create latest VMinsert, VMselect, VMstorage, VMalert container images for victoria-metrics-k8s-stack

### DIFF
--- a/.github/workflows/docker.io.bats.bats.1.11.1.yaml
+++ b/.github/workflows/docker.io.bats.bats.1.11.1.yaml
@@ -21,12 +21,12 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
-name: docker.io/bats/bats:v1.11
+name: docker.io/bats/bats:1.11.1
 on:
   push:
     paths:
-      - .github/workflows/docker.io.bats.bats.v1.11.yaml
-      - docker.io/bats/bats/v1.11/**
+      - .github/workflows/docker.io.bats.bats.1.11.1.yaml
+      - docker.io/bats/bats/1.11.1/**
   workflow_dispatch:
 jobs:
   build:
@@ -35,9 +35,9 @@ jobs:
       contents: read
       id-token: write
     env:
-      CONTEXT_PATH: docker.io/bats/bats/v1.11
+      CONTEXT_PATH: docker.io/bats/bats/1.11.1
       DOCKER_REPO: artifactory.algol60.net/csm-docker/${{ github.ref == 'refs/heads/main' && 'stable' || 'unstable' }}/docker.io/bats/bats
-      DOCKER_TAG: v1.11
+      DOCKER_TAG: 1.11.1
     steps:
       - name: build-sign-scan
         uses: Cray-HPE/github-actions/build-sign-scan@build-sign-scan/v2

--- a/docker.io/bats/bats/1.11.1/Dockerfile
+++ b/docker.io/bats/bats/1.11.1/Dockerfile
@@ -21,7 +21,7 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
-FROM docker.io/bats/bats:v1.11.1
+FROM docker.io/bats/bats:1.11.1
 
 RUN apk update && \
     apk add --upgrade apk-tools &&  \


### PR DESCRIPTION
## Summary and Scope

This PR is to add the missed bats/bats:1.11.1 workflow in this PR https://github.com/Cray-HPE/container-images/pull/685

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves https://jira-pro.it.hpe.com:8443/browse/CASMMON-520


### Tested on:

  * tyr

<img width="1512" alt="Screenshot 2025-04-17 at 8 28 22 AM" src="https://github.com/user-attachments/assets/3e25b5eb-fb29-40bd-bce5-4c03ab6b280e" />


