### PR TITLE
CASMPET-7512: K8s 1.29 wants coredns v1.11.1

### DIFF
--- a/.github/workflows/registry.k8s.io.coredns.coredns.v1.11.1.yaml
+++ b/.github/workflows/registry.k8s.io.coredns.coredns.v1.11.1.yaml
@@ -1,0 +1,59 @@
+#
+# MIT License
+#
+# (C) Copyright [2025] Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+
+# Generated with: make add IMAGE=coredns/coredns:v1.11.1 REGISTRY=registry.k8s.io PACKAGE_MANAGER=
+#
+---
+name: registry.k8s.io/coredns/coredns:v1.11.1
+on:
+  push:
+    paths:
+      - .github/workflows/registry.k8s.io.coredns.coredns.v1.11.1.yaml
+      - registry.k8s.io/coredns/coredns/v1.11.1/**
+  workflow_dispatch:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      CONTEXT_PATH: registry.k8s.io/coredns/coredns/v1.11.1
+      DOCKER_REPO: artifactory.algol60.net/csm-docker/${{ github.ref == 'refs/heads/main' && 'stable' || 'unstable' }}/registry.k8s.io/coredns/coredns
+      DOCKER_TAG: "v1.11.1"
+    steps:
+      - name: build-sign-scan
+        uses: Cray-HPE/github-actions/build-sign-scan@build-sign-scan/v2
+        with:
+          context_path: ${{ env.CONTEXT_PATH }}
+          docker_repo: ${{ env.DOCKER_REPO }}
+          docker_tag: "${{ env.DOCKER_TAG }}"
+          docker_username: ${{ secrets.ARTIFACTORY_ALGOL60_USERNAME }}
+          docker_password: ${{ secrets.ARTIFACTORY_ALGOL60_TOKEN }}
+          sign: ${{ github.ref == 'refs/heads/main' }}
+          cosign_gcp_workload_identity_provider: ${{ secrets.COSIGN_GCP_WORKLOAD_IDENTITY_PROVIDER_RSA }}
+          cosign_gcp_service_account: ${{ secrets.COSIGN_GCP_SERVICE_ACCOUNT_RSA }}
+          cosign_key: ${{ secrets.COSIGN_KEY_RSA }}
+          snyk_token: ${{ secrets.SNYK_TOKEN }}
+          fail_on_snyk_errors: true

--- a/registry.k8s.io/coredns/coredns/v1.11.1/Dockerfile
+++ b/registry.k8s.io/coredns/coredns/v1.11.1/Dockerfile
@@ -1,0 +1,27 @@
+#
+# MIT License
+#
+# (C) Copyright [2025] Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+
+# Generated with: make add IMAGE=coredns/coredns:v1.11.1 REGISTRY=registry.k8s.io PACKAGE_MANAGER=
+#
+FROM registry.k8s.io/coredns/coredns:v1.11.1


### PR DESCRIPTION
## Summary and Scope

While manually upgrading K8s to version 1.29.15, `kubeadm upgrade plan` calls out `coredns` version v1.11.1.

```
Components that must be upgraded manually after you have upgraded the control plane with 'kubeadm upgrade apply':
COMPONENT   CURRENT        TARGET
kubelet     6 x v1.28.15   v1.29.15

Upgrade to the latest stable version:

COMPONENT                 CURRENT    TARGET
kube-apiserver            v1.28.15   v1.29.15
kube-controller-manager   v1.28.15   v1.29.15
kube-scheduler            v1.28.15   v1.29.15
kube-proxy                v1.28.15   v1.29.15
CoreDNS                   v1.10.1    v1.11.1
```


## Issues and Related PRs

* Relates to [CASMPET-7512](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7512)

## Testing

This is being tested on the vShasta system `molly`.

## Pull Request Checklist

- [x ] Version number(s) incremented, if applicable
- [x ] Copyrights updated
- [x ] License file intact
- [x ] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

