### PR TITLE
CASMPET-7478: Upgrade to spilo-15:3.2-p1 for less CVEs

### DIFF
--- a/.github/workflows/ghcr.io.zalando.spilo-15.3.2-p1.yaml
+++ b/.github/workflows/ghcr.io.zalando.spilo-15.3.2-p1.yaml
@@ -1,0 +1,59 @@
+#
+# MIT License
+#
+# (C) Copyright [2025] Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+
+# Generated with: make add IMAGE=zalando/spilo-15:3.2-p1 REGISTRY=ghcr.io PACKAGE_MANAGER=apt
+#
+---
+name: ghcr.io/zalando/spilo-15:3.2-p1
+on:
+  push:
+    paths:
+      - .github/workflows/ghcr.io.zalando.spilo-15.3.2-p1.yaml
+      - ghcr.io/zalando/spilo-15/3.2-p1/**
+  workflow_dispatch:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      CONTEXT_PATH: ghcr.io/zalando/spilo-15/3.2-p1
+      DOCKER_REPO: artifactory.algol60.net/csm-docker/${{ github.ref == 'refs/heads/main' && 'stable' || 'unstable' }}/ghcr.io/zalando/spilo-15
+      DOCKER_TAG: "3.2-p1"
+    steps:
+      - name: build-sign-scan
+        uses: Cray-HPE/github-actions/build-sign-scan@build-sign-scan/v2
+        with:
+          context_path: ${{ env.CONTEXT_PATH }}
+          docker_repo: ${{ env.DOCKER_REPO }}
+          docker_tag: "${{ env.DOCKER_TAG }}"
+          docker_username: ${{ secrets.ARTIFACTORY_ALGOL60_USERNAME }}
+          docker_password: ${{ secrets.ARTIFACTORY_ALGOL60_TOKEN }}
+          sign: ${{ github.ref == 'refs/heads/main' }}
+          cosign_gcp_workload_identity_provider: ${{ secrets.COSIGN_GCP_WORKLOAD_IDENTITY_PROVIDER_RSA }}
+          cosign_gcp_service_account: ${{ secrets.COSIGN_GCP_SERVICE_ACCOUNT_RSA }}
+          cosign_key: ${{ secrets.COSIGN_KEY_RSA }}
+          snyk_token: ${{ secrets.SNYK_TOKEN }}
+          fail_on_snyk_errors: false # upstream image

--- a/ghcr.io/zalando/spilo-15/3.2-p1/Dockerfile
+++ b/ghcr.io/zalando/spilo-15/3.2-p1/Dockerfile
@@ -1,0 +1,38 @@
+#
+# MIT License
+#
+# (C) Copyright [2025] Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+FROM ghcr.io/zalando/spilo-15:3.2-p1
+ENV DEBIAN_FRONTEND=noninteractive
+
+# pgbouncer auto upgrade can not be run in noninteractive mode
+# force upgrade/reinstall
+RUN apt-get -o Dpkg::Options::="--force-confnew" install pgbouncer && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN mkdir /home/postgres/log /home/postgres/pid
+RUN chown -R 101:103 /home/postgres/log /home/postgres/pid
+
+# Capture psql version and packages to the build logs
+RUN psql --version && dpkg -l
+
+USER 101:103


### PR DESCRIPTION
## Summary and Scope

CASMPET-7478: Upgrade to spilo-15:3.2-p1 for less CVEs

Create container image for `spilo-15:3.2-p1` to use with `cray-postgres-operator`.  It has less "High Severity" CVEs than `spilo-15:3.0-p1` which is what `cray-postgres-operator` uses now.

## Testing
Cracked open `cray-postgres-operator` chart and used `spilo-15:3.2-p1` on `beau` to see if there were any obvious problems using the image.

```
pit:~/studenym/cray-postgres-operator/cray-postgres-operator # helm upgrade -n services cray-postgres-operator .
Release "cray-postgres-operator" has been upgraded. Happy Helming!
NAME: cray-postgres-operator
LAST DEPLOYED: Tue Sep  9 18:55:38 2025
NAMESPACE: services
STATUS: deployed
REVISION: 2
TEST SUITE: None
NOTES:
To verify that postgres-operator has started, run:

  kubectl --namespace=services get pods -l "app.kubernetes.io/instance=cray-postgres-operator"
pit:~/studenym/cray-postgres-operator/cray-postgres-operator # kubectl --namespace=services get pods -l "app.kubernetes.io/instance=cray-postgres-operator"
NAME                                     READY   STATUS    RESTARTS   AGE
cray-postgres-operator-5c58df5fc-5cqpt   2/2     Running   0          34s
pit:~/studenym/cray-postgres-operator/cray-postgres-operator # kubectl get pods -n services -l "app.kubernetes.io/instance=cray-postgres-operator"
NAME                                     READY   STATUS    RESTARTS   AGE
cray-postgres-operator-5c58df5fc-5cqpt   2/2     Running   0          72s
pit:~/studenym/cray-postgres-operator/cray-postgres-operator # helm history -n services cray-postgres-operator
REVISION	UPDATED                 	STATUS    	CHART                        	APP VERSION	DESCRIPTION
1       	Mon Aug 11 15:11:18 2025	superseded	cray-postgres-operator-1.10.3	1.10.1     	Install complete
2       	Tue Sep  9 18:55:38 2025	deployed  	cray-postgres-operator-1.10.4	1.10.1     	Upgrade complete

pit:~/studenym/cray-postgres-operator/cray-postgres-operator # kubectl get pods -A | grep postgres
argo              cray-nls-postgres-0                                               3/3     Running     0             3m18s
argo              cray-nls-postgres-1                                               3/3     Running     0             4m35s
argo              cray-nls-postgres-2                                               3/3     Running     0             3m56s
services          cfs-ara-postgres-0                                                3/3     Running     0             3m30s
services          cfs-ara-postgres-1                                                3/3     Running     0             4m40s
services          cfs-ara-postgres-2                                                3/3     Running     0             4m2s
services          cfs-ara-wait-for-postgres-1-gdzx6                                 0/2     Completed   0             29d
services          cray-console-data-postgres-0                                      3/3     Running     0             3m25s
services          cray-console-data-postgres-1                                      3/3     Running     0             4m38s
services          cray-console-data-postgres-2                                      3/3     Running     0             3m56s
services          cray-console-data-wait-for-postgres-1-xq5gd                       0/2     Completed   0             29d
services          cray-dhcp-kea-postgres-0                                          3/3     Running     0             3m19s
services          cray-dhcp-kea-postgres-1                                          3/3     Running     0             4m35s
services          cray-dhcp-kea-postgres-2                                          3/3     Running     0             3m56s
services          cray-dns-powerdns-postgres-0                                      3/3     Running     0             3m18s
services          cray-dns-powerdns-postgres-1                                      3/3     Running     0             4m35s
services          cray-dns-powerdns-postgres-2                                      3/3     Running     0             3m56s
services          cray-dns-powerdns-wait-for-postgres-1-xvhtr                       0/3     Completed   0             29d
services          cray-postgres-operator-5c58df5fc-5cqpt                            2/2     Running     0             5m26s
services          cray-postgres-operator-inject-secret-hhg9r                        0/1     Completed   0             5m28s
services          cray-sls-postgres-0                                               3/3     Running     0             3m35s
services          cray-sls-postgres-1                                               3/3     Running     0             4m37s
services          cray-sls-postgres-2                                               3/3     Running     0             4m
services          cray-sls-wait-for-postgres-1-5gsx7                                0/3     Completed   0             29d
services          cray-smd-postgres-0                                               3/3     Running     0             3m30s
services          cray-smd-postgres-1                                               3/3     Running     0             4m37s
services          cray-smd-postgres-2                                               3/3     Running     0             4m1s
services          cray-smd-wait-for-postgres-1-2xpt4                                0/3     Completed   0             29d
services          gitea-vcs-postgres-0                                              3/3     Running     0             3m35s
services          gitea-vcs-postgres-1                                              3/3     Running     0             4m40s
services          gitea-vcs-postgres-2                                              3/3     Running     0             4m1s
services          gitea-vcs-wait-for-postgres-1-lj59l                               0/2     Completed   0             29d
services          keycloak-postgres-0                                               3/3     Running     0             2m2s
services          keycloak-postgres-1                                               3/3     Running     0             2m52s
services          keycloak-postgres-2                                               3/3     Running     0             2m33s
services          keycloak-wait-for-postgres-1-lxltf                                0/2     Completed   0             29d
spire             cray-spire-postgres-0                                             3/3     Running     0             2m11s
spire             cray-spire-postgres-1                                             3/3     Running     0             3m4s
spire             cray-spire-postgres-2                                             3/3     Running     0             2m36s
spire             cray-spire-postgres-pooler-8585bdf864-4wxl7                       2/2     Running     0             29d
spire             cray-spire-postgres-pooler-8585bdf864-nsbhj                       2/2     Running     0             29d
spire             cray-spire-postgres-pooler-8585bdf864-s2j49                       2/2     Running     0             29d
pit:~/studenym/cray-postgres-operator/cray-postgres-operator # kubectl get postgresql -A
NAMESPACE   NAME                         TEAM                VERSION   PODS   VOLUME   CPU-REQUEST   MEMORY-REQUEST   AGE   STATUS
argo        cray-nls-postgres            cray-nls            15        3      2Gi                                     29d   Running
services    cfs-ara-postgres             cfs-ara             15        3      50Gi     100m          100Mi            29d   Running
services    cray-console-data-postgres   cray-console-data   15        3      2Gi      100m          256Mi            29d   Running
services    cray-dhcp-kea-postgres       cray-dhcp-kea       15        3      10Gi     500m          1Gi              29d   Running
services    cray-dns-powerdns-postgres   cray-dns-powerdns   15        3      10Gi     100m          100Mi            29d   Running
services    cray-sls-postgres            cray-sls            15        3      1Gi      100m          128Mi            29d   Running
services    cray-smd-postgres            cray-smd            15        3      100Gi    100m          100Mi            29d   Running
services    gitea-vcs-postgres           gitea-vcs           15        3      50Gi     100m          256Mi            29d   Running
services    keycloak-postgres            keycloak            15        3      10Gi                                    29d   Running
spire       cray-spire-postgres          cray-spire          15        3      60Gi     500m          1Gi              29d   Running
pit:~/studenym/cray-postgres-operator/cray-postgres-operator # kubectl get pods -n argo
NAME                                                           READY   STATUS    RESTARTS      AGE
cray-iuf-metacontroller-helm-0                                 2/2     Running   0             29d
cray-iuf-metacontroller-helm-1                                 2/2     Running   0             29d
cray-nls-7cf458ff5c-8285k                                      2/2     Running   2 (29d ago)   29d
cray-nls-7cf458ff5c-86h9q                                      2/2     Running   2 (29d ago)   29d
cray-nls-7cf458ff5c-bkpn4                                      2/2     Running   2 (29d ago)   29d
cray-nls-argo-workflows-server-66df4b8868-54qzv                2/2     Running   4 (29d ago)   29d
cray-nls-argo-workflows-server-66df4b8868-qjkcr                2/2     Running   4 (29d ago)   29d
cray-nls-argo-workflows-workflow-controller-78d65cc7bc-bchg9   2/2     Running   4 (29d ago)   29d
cray-nls-argo-workflows-workflow-controller-78d65cc7bc-mm5nd   2/2     Running   4 (29d ago)   29d
cray-nls-postgres-0                                            3/3     Running   0             5m3s
cray-nls-postgres-1                                            3/3     Running   0             6m20s
cray-nls-postgres-2                                            3/3     Running   0             5m41s
pit:~/studenym/cray-postgres-operator/cray-postgres-operator # kubectl exec -it -n argo cray-nls-postgres-0 -- sh
$ patronictl version
patronictl version 3.2.2
$ patronictl list
+ Cluster: cray-nls-postgres (7537346219949789252) -------+----+-----------+
| Member              | Host        | Role    | State     | TL | Lag in MB |
+---------------------+-------------+---------+-----------+----+-----------+
| cray-nls-postgres-0 | 10.32.3.229 | Replica | streaming |  2 |         0 |
| cray-nls-postgres-1 | 10.32.2.227 | Leader  | running   |  2 |           |
| cray-nls-postgres-2 | 10.32.4.212 | Replica | streaming |  2 |         0 |
+---------------------+-------------+---------+-----------+----+-----------+
$ exit
pit:~/studenym/cray-postgres-operator/cray-postgres-operator # kubectl get pods -n argo cray-nls-postgres-0 -o yaml | grep image
    sidecar.istio.io/status: '{"initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["workload-socket","credential-socket","workload-certs","istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null,"revision":"default"}'
    image: artifactory.algol60.net/csm-docker/stable/istio/proxyv2:1.26.0-cray1-distroless
    imagePullPolicy: IfNotPresent
    image: artifactory.algol60.net/csm-docker/stable/ghcr.io/zalando/spilo-15:3.2-p1
    imagePullPolicy: IfNotPresent
    image: artifactory.algol60.net/csm-docker/stable/docker.io/wrouesnel/postgres_exporter:0.8.2
    imagePullPolicy: IfNotPresent
    image: artifactory.algol60.net/csm-docker/stable/istio/proxyv2:1.26.0-cray1-distroless
    imagePullPolicy: IfNotPresent
    image: artifactory.algol60.net/csm-docker/stable/docker.io/wrouesnel/postgres_exporter:0.8.2
    imageID: artifactory.algol60.net/csm-docker/stable/docker.io/wrouesnel/postgres_exporter@sha256:b1a9506fa9cfe12b9055372687b300e4095445dc6f977b3eca6f262224995f68
    image: artifactory.algol60.net/csm-docker/stable/istio/proxyv2:1.26.0-cray1-distroless
    imageID: artifactory.algol60.net/csm-docker/stable/istio/proxyv2@sha256:ac79eb00cbac97e2b7f17cb42bb0b1d4b3663308b75eb26bd1c7dd0f7be1e441
    image: artifactory.algol60.net/csm-docker/stable/ghcr.io/zalando/spilo-15:3.2-p1
    imageID: artifactory.algol60.net/csm-docker/stable/ghcr.io/zalando/spilo-15@sha256:d37b0a92c8b2a7149e4246eee06e325fb34835575797ad036bbad40959d6ab13
    image: artifactory.algol60.net/csm-docker/stable/istio/proxyv2:1.26.0-cray1-distroless
    imageID: artifactory.algol60.net/csm-docker/stable/istio/proxyv2@sha256:ac79eb00cbac97e2b7f17cb42bb0b1d4b3663308b75eb26bd1c7dd0f7be1e441
pit:~/studenym/cray-postgres-operator/cray-postgres-operator #
```

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

