### PR TITLE
CASMNET-2120: Add multus-cni v4.2.2

### DIFF
--- a/.github/workflows/ghcr.io.k8snetworkplumbingwg.multus-cni.v4.2.2.yaml
+++ b/.github/workflows/ghcr.io.k8snetworkplumbingwg.multus-cni.v4.2.2.yaml
@@ -1,0 +1,55 @@
+#
+# MIT License
+#
+# (C) Copyright 2025 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+name: ghcr.io/k8snetworkplumbingwg/multus-cni:v4.2.2
+on:
+  push:
+    paths:
+      - .github/workflows/ghcr.io.k8snetworkplumbingwg.multus-cni.v4.2.2.yaml
+      - ghcr.io/k8snetworkplumbingwg/multus-cni/v4.2.2/**
+  workflow_dispatch:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      CONTEXT_PATH: ghcr.io/k8snetworkplumbingwg/multus-cni/v4.2.2
+      DOCKER_REPO: artifactory.algol60.net/csm-docker/${{ github.ref == 'refs/heads/main' && 'stable' || 'unstable' }}/ghcr.io/k8snetworkplumbingwg/multus-cni
+      DOCKER_TAG: v4.2.2
+    steps:
+      - name: build-sign-scan
+        uses: Cray-HPE/github-actions/build-sign-scan@build-sign-scan/v2
+        with:
+          context_path: ${{ env.CONTEXT_PATH }}
+          docker_repo: ${{ env.DOCKER_REPO }}
+          docker_tag: ${{ env.DOCKER_TAG }}
+          docker_username: ${{ secrets.ARTIFACTORY_ALGOL60_USERNAME }}
+          docker_password: ${{ secrets.ARTIFACTORY_ALGOL60_TOKEN }}
+          sign: ${{ github.ref == 'refs/heads/main' }}
+          cosign_gcp_workload_identity_provider: ${{ secrets.COSIGN_GCP_WORKLOAD_IDENTITY_PROVIDER_RSA }}
+          cosign_gcp_service_account: ${{ secrets.COSIGN_GCP_SERVICE_ACCOUNT_RSA }}
+          cosign_key: ${{ secrets.COSIGN_KEY_RSA }}
+          snyk_token: ${{ secrets.SNYK_TOKEN }}
+          fail_on_snyk_errors: false

--- a/ghcr.io/k8snetworkplumbingwg/multus-cni/v4.2.2/Dockerfile
+++ b/ghcr.io/k8snetworkplumbingwg/multus-cni/v4.2.2/Dockerfile
@@ -1,0 +1,40 @@
+#
+# MIT License
+#
+# (C) Copyright [2025] Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+FROM ghcr.io/k8snetworkplumbingwg/multus-cni:v4.2.2 AS base
+
+# Use latest base image
+FROM python:slim
+WORKDIR /
+# Copy necessary files from base
+COPY --from=base /usr/src/multus-cni/bin /usr/src/multus-cni/bin
+COPY --from=base /usr/src/multus-cni/bin/install_multus /
+COPY --from=base /usr/src/multus-cni/bin/thin_entrypoint /
+COPY --from=base /usr/src/multus-cni/bin/kubeconfig_generator /
+COPY --from=base /usr/src/multus-cni/bin/cert-approver /
+
+RUN apt-get -y update && apt-get upgrade -y && apt full-upgrade -y\
+    && rm -rf /var/lib/apt/lists/
+
+# Set the entrypoint
+ENTRYPOINT ["/thin_entrypoint"]


### PR DESCRIPTION
## Summary and Scope
CASMNET-2120: Add multus-cni v4.2.2
* Need to use thin_entrypoint; Copy COPY statements from multus-cni repo Dockerfile

## Issues and Related PRs
* Image for [CASMNET-2120](https://jira-pro.it.hpe.com:8443/browse/CASMNET-2120)

## Testing
Was able to get this image to run on `beau` with changes to the `kube-multus-ds` daemonset.  The daemonset changes will need to be made in the `node-images` repo.

daemonset changes:
```
    spec:
      containers:
      - args:
        - --cni-conf-dir=/host/etc/cni/net.d
        - --cni-bin-dir=/host/opt/cni/bin
        - --multus-conf-file=/usr/src/multus-cni/images/00-multus.conf
        - --cni-version=0.3.1
        command:
        - "/thin_entrypoint"
        image: artifactory.algol60.net/csm-docker/stable/ghcr.io/k8snetworkplumbingwg/multus-cni:v4.2.2

<snip>

      initContainers:
      - command: ["/install_multus"]
        args:
          - "--type"
          - "thin"
        image: artifactory.algol60.net/csm-docker/stable/ghcr.io/k8snetworkplumbingwg/multus-cni:v4.2.2

```

Applied modified daemonset that uses new container image
```
ncn-m001:~/studenym # kubectl apply -f kube-multus-ds-v4.2.2.yaml
daemonset.apps/kube-multus-ds configured
ncn-m001:~/studenym #
ncn-m001:~/studenym # kubectl get all -n kube-system -o wide | grep multus
pod/kube-multus-ds-5hw5t               1/1     Running     0               2m39s   10.252.1.9    ncn-m002   <none>           <none>
pod/kube-multus-ds-fctgq               1/1     Running     0               68s     10.252.1.7    ncn-w003   <none>           <none>
pod/kube-multus-ds-l6jbw               1/1     Running     0               2m15s   10.252.1.10   ncn-m003   <none>           <none>
pod/kube-multus-ds-lvfsb               1/1     Running     0               3m1s    10.252.1.5    ncn-w001   <none>           <none>
pod/kube-multus-ds-nhpjq               1/1     Running     0               91s     10.252.1.8    ncn-m001   <none>           <none>
pod/kube-multus-ds-vpwll               1/1     Running     0               110s    10.252.1.6    ncn-w002   <none>           <none>
daemonset.apps/kube-multus-ds          6         6         6       6            6           <none>                   7d20h   kube-multus             artifactory.algol60.net/csm-docker/stable/ghcr.io/k8snetworkplumbingwg/multus-cni:v4.2.2   name=multus
ncn-m001:~/studenym # kubectl get pod -n kube-system kube-multus-ds-5hw5t -o yaml | grep image:
    image: artifactory.algol60.net/csm-docker/stable/ghcr.io/k8snetworkplumbingwg/multus-cni:v4.2.2
    image: artifactory.algol60.net/csm-docker/stable/ghcr.io/k8snetworkplumbingwg/multus-cni:v4.2.2
    image: artifactory.algol60.net/csm-docker/stable/ghcr.io/k8snetworkplumbingwg/multus-cni:v4.2.2
    image: artifactory.algol60.net/csm-docker/stable/ghcr.io/k8snetworkplumbingwg/multus-cni:v4.2.2
ncn-m001:~/studenym #
```

## Risks and Mitigations
Low, at this point, since nothing is currently trying to use this image.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

